### PR TITLE
feat(templates): Update to new spring cloudant templates

### DIFF
--- a/generator-java/lib/assert/internal/assert.core.bx.js
+++ b/generator-java/lib/assert/internal/assert.core.bx.js
@@ -67,7 +67,7 @@ class AssertBx extends Assert {
     })
   }
 
-  assertCloudant (exists, buildType, frameworkType) {
+  assertCloudant ({exists, buildType, frameworkType}) {
     if (exists) {
       it('should create Cloudant README entry', function () {
         assert.fileContent('README.md', 'cloudant')
@@ -128,7 +128,7 @@ class AssertBx extends Assert {
     })
   }
 
-  assertObjectStorage (exists, buildType) {
+  assertObjectStorage ({exists, buildType}) {
     const check = this.getCheck(exists)
     it(check.desc + 'Object Storage README entry', function () {
       if (exists) {

--- a/generator-java/lib/assert/internal/assert.core.bx.js
+++ b/generator-java/lib/assert/internal/assert.core.bx.js
@@ -67,7 +67,7 @@ class AssertBx extends Assert {
     })
   }
 
-  assertCloudant ({exists, buildType}) {
+  assertCloudant (exists, buildType, frameworkType) {
     if (exists) {
       it('should create Cloudant README entry', function () {
         assert.fileContent('README.md', 'cloudant')
@@ -77,7 +77,12 @@ class AssertBx extends Assert {
         assert.fileContent(constant.LOCALDEV_FILE, '"cloudant_password": "pass"')
         assert.fileContent(constant.LOCALDEV_FILE, '"cloudant_url": "https://account.cloudant.com"')
       })
-      tests.test(buildType).assertDependency('compile', 'com.cloudant', 'cloudant-client', '2.7.0')
+      if(frameworkType === constant.FRAMEWORK_LIBERTY) {
+        tests.test(buildType).assertDependency('compile', 'com.cloudant', 'cloudant-client', '2.7.0')
+      }
+      if(frameworkType === constant.FRAMEWORK_SPRING) {
+        tests.test(buildType).assertDependency('compile', 'com.cloudant', 'cloudant-spring-boot-starter', '0.0.2')
+      }
     }
   }
 
@@ -123,7 +128,7 @@ class AssertBx extends Assert {
     })
   }
 
-  assertObjectStorage ({exists, buildType}) {
+  assertObjectStorage (exists, buildType) {
     const check = this.getCheck(exists)
     it(check.desc + 'Object Storage README entry', function () {
       if (exists) {

--- a/generator-java/lib/assert/starters/assert.basicweb.js
+++ b/generator-java/lib/assert/starters/assert.basicweb.js
@@ -56,12 +56,7 @@ class AssertBasicWeb extends AssertBx {
   }
 
   assertCloudant ({exists, buildType, frameworkType}) {
-    super.assertCloudant({exists: exists, buildType: buildType})
-    if (exists && (frameworkType === constant.FRAMEWORK_SPRING)) {
-      it('should contain @Lazy for cloudant client', function () {
-        assert.fileContent('src/main/java/application/cloudant/CloudantClientConfig.java', '@Lazy')
-      })
-    }
+    super.assertCloudant({exists: exists, buildType: buildType, frameworkType: frameworkType})
   }
 
   assertObjectStorage ({exists, buildType, frameworkType}) {

--- a/generator-java/lib/assert/starters/assert.bff.js
+++ b/generator-java/lib/assert/starters/assert.bff.js
@@ -68,8 +68,8 @@ class AssertBFF extends AssertBx {
     })
   }
 
-  assertCloudant ({exists, buildType}) {
-    super.assertCloudant(exists, buildType)
+  assertCloudant ({exists, buildType, frameworkType}) {
+    super.assertCloudant({exists: exists, buildType: buildType, frameworkType: frameworkType})
     const check = super.getCheck(exists);
     if(this.frameworkType === 'liberty') {
       //make sure Spring specific files are not generated

--- a/generator-java/lib/assert/starters/assert.enable.js
+++ b/generator-java/lib/assert/starters/assert.enable.js
@@ -25,8 +25,8 @@ const USAGE_TXT = 'usage.txt'
 
 class AssertEnable extends AssertBx {
   assert (appName, ymlName, buildType, frameworkType, createType) {
-    super.assertCloudant(false, buildType)
-    super.assertObjectStorage(false, buildType)
+    super.assertCloudant({exists: false, buildType: buildType, frameworkType: frameworkType})
+    super.assertObjectStorage({exists: false, buildType: buildType})
     it('generates ' + USAGE_TXT + ' file', function () {
       assert.file(USAGE_TXT)
     })

--- a/generator-java/lib/assert/starters/assert.microservice.js
+++ b/generator-java/lib/assert/starters/assert.microservice.js
@@ -57,7 +57,7 @@ class AssertMicroservice extends AssertBx {
   }
 
   assertCloudant ({exists, buildType, frameworkType}) {
-    super.assertCloudant(exists, buildType, frameworkType)
+    super.assertCloudant({exists: exists, buildType: buildType, frameworkType: frameworkType})
     const check = this.getCheck(exists)
     const invcheck = this.getCheck(exists ^ exists)
     it(check.desc + 'common cloudant source files', function () {
@@ -84,7 +84,7 @@ class AssertMicroservice extends AssertBx {
   }
 
   assertObjectStorage ({exists, buildType, frameworkType}) {
-    super.assertObjectStorage(exists, buildType)
+    super.assertObjectStorage({exists: exists, buildType: buildType})
     const check = this.getCheck(exists)
     const invcheck = this.getCheck(exists ^ exists)
     it(check.desc + 'Object Storage source files', function () {

--- a/generator-java/lib/assert/starters/assert.microservice.js
+++ b/generator-java/lib/assert/starters/assert.microservice.js
@@ -25,8 +25,8 @@ const tests = require('ibm-java-codegen-common')
 class AssertMicroservice extends AssertBx {
   assert (appName, ymlName, buildType, frameworkType, createType, cloudant, objectStorage) {
     super.assert(appName, ymlName, buildType, frameworkType, createType, cloudant, objectStorage)
-    this.assertCloudant({exists: cloudant, frameworkType: frameworkType})
-    this.assertObjectStorage({exists: objectStorage, frameworkType: frameworkType})
+    this.assertCloudant({exists: cloudant, buildType: buildType, frameworkType: frameworkType})
+    this.assertObjectStorage({exists: objectStorage, buildType: buildType, frameworkType: frameworkType})
     this.assertToolchainBxCreate()
     it('Check that common source files exist', function () {
       assert.fileContent('src/main/java/application/rest/v1/Example.java', 'Congratulations')
@@ -56,8 +56,8 @@ class AssertMicroservice extends AssertBx {
     })
   }
 
-  assertCloudant ({exists, frameworkType}) {
-    super.assertCloudant(exists)
+  assertCloudant ({exists, buildType, frameworkType}) {
+    super.assertCloudant(exists, buildType, frameworkType)
     const check = this.getCheck(exists)
     const invcheck = this.getCheck(exists ^ exists)
     it(check.desc + 'common cloudant source files', function () {
@@ -78,14 +78,13 @@ class AssertMicroservice extends AssertBx {
         invcheck.file('src/main/java/application/cloudant/Cloudant.java')
       })
       it(check.desc + 'Spring cloudant source files', function () {
-        check.file('src/main/java/application/cloudant/CloudantClientConfig.java')
         check.content('src/main/java/application/Info.java', 'http://localhost:8080/v1/cloudant') // standard info is there
       })
     }
   }
 
-  assertObjectStorage ({exists, frameworkType}) {
-    super.assertObjectStorage(exists)
+  assertObjectStorage ({exists, buildType, frameworkType}) {
+    super.assertObjectStorage(exists, buildType)
     const check = this.getCheck(exists)
     const invcheck = this.getCheck(exists ^ exists)
     it(check.desc + 'Object Storage source files', function () {

--- a/generator-java/package-lock.json
+++ b/generator-java/package-lock.json
@@ -8,7 +8,6 @@
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.2.tgz",
       "integrity": "sha1-wQI3G27Dp887hHygDCC7D85Mbeo=",
-      "dev": true,
       "requires": {
         "jsonparse": "1.3.1",
         "through": "2.3.8"
@@ -100,14 +99,12 @@
     "array-find-index": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
-      "integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E=",
-      "dev": true
+      "integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E="
     },
     "array-ify": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/array-ify/-/array-ify-1.0.0.tgz",
-      "integrity": "sha1-nlKHYrSpBmrRY6aWKjZEGOlibs4=",
-      "dev": true
+      "integrity": "sha1-nlKHYrSpBmrRY6aWKjZEGOlibs4="
     },
     "array-union": {
       "version": "1.0.2",
@@ -184,7 +181,7 @@
     },
     "binary": {
       "version": "0.3.0",
-      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/binary/-/binary-0.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/binary/-/binary-0.3.0.tgz",
       "integrity": "sha1-n2BVO8XOjDOG87VTz/R0Yq3sqnk=",
       "requires": {
         "buffers": "0.1.1",
@@ -226,7 +223,7 @@
     },
     "buffers": {
       "version": "0.1.1",
-      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/buffers/-/buffers-0.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/buffers/-/buffers-0.1.1.tgz",
       "integrity": "sha1-skV5w77U1tOWru5tmorn9Ugqt7s="
     },
     "builtin-modules": {
@@ -259,7 +256,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
       "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
-      "dev": true,
       "requires": {
         "camelcase": "2.1.1",
         "map-obj": "1.0.1"
@@ -268,8 +264,7 @@
         "camelcase": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
-          "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8=",
-          "dev": true
+          "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8="
         }
       }
     },
@@ -295,7 +290,7 @@
     },
     "chainsaw": {
       "version": "0.1.0",
-      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/chainsaw/-/chainsaw-0.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/chainsaw/-/chainsaw-0.1.0.tgz",
       "integrity": "sha1-XqtQsor+WAdNDVgpE4iCi15fvJg=",
       "requires": {
         "traverse": "0.3.9"
@@ -316,13 +311,12 @@
     "chardet": {
       "version": "0.4.2",
       "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.4.2.tgz",
-      "integrity": "sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I=",
-      "dev": true
+      "integrity": "sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I="
     },
     "circular-json": {
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.3.tgz",
-      "integrity": "sha1-gVyZ6oT2gJUp0vRXkb34JxE1LWY=",
+      "integrity": "sha512-UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A==",
       "dev": true
     },
     "class-extend": {
@@ -411,8 +405,7 @@
     "color-convert": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
-      "integrity": "sha1-wSYRB66y8pTr/+ye2eytUppgl+0=",
-      "dev": true,
+      "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
       "requires": {
         "color-name": "1.1.3"
       }
@@ -420,8 +413,7 @@
     "color-name": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-      "dev": true
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
     },
     "colors": {
       "version": "1.0.3",
@@ -439,14 +431,13 @@
     "commander": {
       "version": "2.12.2",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.12.2.tgz",
-      "integrity": "sha1-D1lGxCftnsDZGka7ne9T5UZQ5VU=",
+      "integrity": "sha512-BFnaq5ZOGcDN7FlrtBT4xxkgIToalIIxwjxLWVJ8bGTpe1LroqMiqQXdA7ygc7CRvaYS+9zfPGFnJqFSayx+AA==",
       "dev": true
     },
     "common-codegen-tests": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/common-codegen-tests/-/common-codegen-tests-2.2.3.tgz",
       "integrity": "sha1-niMDzptNbHTSe79L5Fqqqg/FhKo=",
-      "dev": true,
       "requires": {
         "js-yaml": "3.10.0",
         "semver": "5.4.1",
@@ -464,7 +455,6 @@
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/compare-func/-/compare-func-1.3.2.tgz",
       "integrity": "sha1-md0LpFfh+bxyKxLAjsM+6rMfpkg=",
-      "dev": true,
       "requires": {
         "array-ify": "1.0.0",
         "dot-prop": "3.0.0"
@@ -489,7 +479,6 @@
       "version": "1.1.7",
       "resolved": "https://registry.npmjs.org/conventional-changelog/-/conventional-changelog-1.1.7.tgz",
       "integrity": "sha1-kVGmKx2O2y2CcR2r9bfPcQQfgrE=",
-      "dev": true,
       "requires": {
         "conventional-changelog-angular": "1.6.0",
         "conventional-changelog-atom": "0.1.2",
@@ -507,7 +496,6 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-1.6.0.tgz",
       "integrity": "sha1-CiagcfLJ/PzyuGugz79uYwG3W/o=",
-      "dev": true,
       "requires": {
         "compare-func": "1.3.2",
         "q": "1.5.1"
@@ -517,7 +505,6 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/conventional-changelog-atom/-/conventional-changelog-atom-0.1.2.tgz",
       "integrity": "sha1-Ella1SZ6aTfDTPkAKBscZRmKTGM=",
-      "dev": true,
       "requires": {
         "q": "1.5.1"
       }
@@ -526,7 +513,6 @@
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/conventional-changelog-codemirror/-/conventional-changelog-codemirror-0.2.1.tgz",
       "integrity": "sha1-KZpPcUe681DmyBWPxUlUopHFzAk=",
-      "dev": true,
       "requires": {
         "q": "1.5.1"
       }
@@ -535,7 +521,6 @@
       "version": "1.9.5",
       "resolved": "https://registry.npmjs.org/conventional-changelog-core/-/conventional-changelog-core-1.9.5.tgz",
       "integrity": "sha1-XbdWba18DLddr0f7spdve/mSjB0=",
-      "dev": true,
       "requires": {
         "conventional-changelog-writer": "2.0.3",
         "conventional-commits-parser": "2.1.0",
@@ -556,7 +541,6 @@
           "version": "1.0.12",
           "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.12.tgz",
           "integrity": "sha1-nxJLZ1lMk3/3BpMuSmQsyo27/uk=",
-          "dev": true,
           "requires": {
             "get-stdin": "4.0.1",
             "meow": "3.7.0"
@@ -566,7 +550,6 @@
           "version": "1.1.2",
           "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
           "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
-          "dev": true,
           "requires": {
             "path-exists": "2.1.0",
             "pinkie-promise": "2.0.1"
@@ -576,7 +559,6 @@
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
           "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
-          "dev": true,
           "requires": {
             "graceful-fs": "4.1.11",
             "parse-json": "2.2.0",
@@ -589,7 +571,6 @@
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
           "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
-          "dev": true,
           "requires": {
             "pinkie-promise": "2.0.1"
           }
@@ -598,7 +579,6 @@
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
           "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
-          "dev": true,
           "requires": {
             "graceful-fs": "4.1.11",
             "pify": "2.3.0",
@@ -609,7 +589,6 @@
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
           "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
-          "dev": true,
           "requires": {
             "load-json-file": "1.1.0",
             "normalize-package-data": "2.4.0",
@@ -620,7 +599,6 @@
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
           "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
-          "dev": true,
           "requires": {
             "find-up": "1.1.2",
             "read-pkg": "1.1.0"
@@ -630,7 +608,6 @@
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
           "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
-          "dev": true,
           "requires": {
             "is-utf8": "0.2.1"
           }
@@ -640,8 +617,7 @@
     "conventional-changelog-ember": {
       "version": "0.2.10",
       "resolved": "https://registry.npmjs.org/conventional-changelog-ember/-/conventional-changelog-ember-0.2.10.tgz",
-      "integrity": "sha1-3NbkzcLmwrWGU89NLLFlamBCGSk=",
-      "dev": true,
+      "integrity": "sha512-LBBBZO6Q7ib4HhSdyCNVR25OtaXl710UJg1aSHCLmR8AjuXKs3BO8tnbY1MH+D1C+z5IFoEDkpjOddefNTyhCQ==",
       "requires": {
         "q": "1.5.1"
       }
@@ -650,7 +626,6 @@
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/conventional-changelog-eslint/-/conventional-changelog-eslint-0.2.1.tgz",
       "integrity": "sha1-LCoRvrIW+AZJunKDQYApO2h8BmI=",
-      "dev": true,
       "requires": {
         "q": "1.5.1"
       }
@@ -659,7 +634,6 @@
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/conventional-changelog-express/-/conventional-changelog-express-0.2.1.tgz",
       "integrity": "sha1-g42eHmyQmXA7FQucGaoteBdCvWw=",
-      "dev": true,
       "requires": {
         "q": "1.5.1"
       }
@@ -668,7 +642,6 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/conventional-changelog-jquery/-/conventional-changelog-jquery-0.1.0.tgz",
       "integrity": "sha1-Agg5cWLjhGmG5xJztsecW1+A9RA=",
-      "dev": true,
       "requires": {
         "q": "1.5.1"
       }
@@ -677,7 +650,6 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/conventional-changelog-jscs/-/conventional-changelog-jscs-0.1.0.tgz",
       "integrity": "sha1-BHnrRDzH1yxYvwvPDvHURKkvDlw=",
-      "dev": true,
       "requires": {
         "q": "1.5.1"
       }
@@ -686,7 +658,6 @@
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/conventional-changelog-jshint/-/conventional-changelog-jshint-0.2.1.tgz",
       "integrity": "sha1-hhObs6yZiZ8rF36WF+CbN9mbzzo=",
-      "dev": true,
       "requires": {
         "compare-func": "1.3.2",
         "q": "1.5.1"
@@ -695,8 +666,7 @@
     "conventional-changelog-writer": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/conventional-changelog-writer/-/conventional-changelog-writer-2.0.3.tgz",
-      "integrity": "sha1-BzsMOfHMj8D9mxVm6Tgz9RSJyBw=",
-      "dev": true,
+      "integrity": "sha512-2E1h7UXL0fhRO5h0CxDZ5EBc5sfBZEQePvuZ+gPvApiRrICUyNDy/NQIP+2TBd4wKZQf2Zm7TxbzXHG5HkPIbA==",
       "requires": {
         "compare-func": "1.3.2",
         "conventional-commits-filter": "1.1.1",
@@ -714,7 +684,6 @@
           "version": "1.0.12",
           "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.12.tgz",
           "integrity": "sha1-nxJLZ1lMk3/3BpMuSmQsyo27/uk=",
-          "dev": true,
           "requires": {
             "get-stdin": "4.0.1",
             "meow": "3.7.0"
@@ -725,8 +694,7 @@
     "conventional-commits-filter": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/conventional-commits-filter/-/conventional-commits-filter-1.1.1.tgz",
-      "integrity": "sha1-chcjGcDIgyigFbMGhrVVJ7Ol5Uo=",
-      "dev": true,
+      "integrity": "sha512-bQyatySNKHhcaeKVr9vFxYWA1W1Tdz6ybVMYDmv4/FhOXY1+fchiW07TzRbIQZhVa4cvBwrEaEUQBbCncFSdJQ==",
       "requires": {
         "is-subset": "0.1.1",
         "modify-values": "1.0.0"
@@ -735,8 +703,7 @@
     "conventional-commits-parser": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-2.1.0.tgz",
-      "integrity": "sha1-m0t8kRJL8qGposwccnYNOCy7sik=",
-      "dev": true,
+      "integrity": "sha512-8MD05yN0Zb6aRsZnFX1ET+8rHWfWJk+my7ANCJZBU2mhz7TSB1fk2vZhkrwVy/PCllcTYAP/1T1NiWQ7Z01mKw==",
       "requires": {
         "JSONStream": "1.3.2",
         "is-text-path": "1.0.1",
@@ -750,8 +717,7 @@
     "conventional-recommended-bump": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/conventional-recommended-bump/-/conventional-recommended-bump-1.1.0.tgz",
-      "integrity": "sha1-lk1PzHD7UlnUH6mznT32r9uH0lM=",
-      "dev": true,
+      "integrity": "sha512-WK0HnYnXd9e8J1YezUlfle+Pz7HB1RYvIH6gPLAXoroQTzDSfNfGM1tHHmdrJw0/4BMr+zw0U9V1WzFEfQwE3w==",
       "requires": {
         "concat-stream": "1.6.0",
         "conventional-commits-filter": "1.1.1",
@@ -765,8 +731,7 @@
         "object-assign": {
           "version": "4.1.1",
           "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-          "dev": true
+          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
         }
       }
     },
@@ -778,7 +743,7 @@
     "coveralls": {
       "version": "2.13.3",
       "resolved": "https://registry.npmjs.org/coveralls/-/coveralls-2.13.3.tgz",
-      "integrity": "sha1-mtfCrlJ0F/Nh6LYmSD9I7pLdK8c=",
+      "integrity": "sha512-iiAmn+l1XqRwNLXhW8Rs5qHZRFMYp9ZIPjEOVRpC/c4so6Y/f4/lFi0FfR5B9cCqgyhkJ5cZmbvcVRfP8MHchw==",
       "dev": true,
       "requires": {
         "js-yaml": "3.6.1",
@@ -978,7 +943,7 @@
         "boom": {
           "version": "5.2.0",
           "resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
-          "integrity": "sha1-XdnabuOl8wIHdDYpDLcX0/SlTgI=",
+          "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
           "requires": {
             "hoek": "4.2.0"
           }
@@ -989,7 +954,6 @@
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
       "integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
-      "dev": true,
       "requires": {
         "array-find-index": "1.0.2"
       }
@@ -1020,7 +984,7 @@
     "debug": {
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
       "requires": {
         "ms": "2.0.0"
       }
@@ -1106,7 +1070,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-3.0.0.tgz",
       "integrity": "sha1-G3CK8JSknJoOfbyteQq6U52sEXc=",
-      "dev": true,
       "requires": {
         "is-obj": "1.0.1"
       }
@@ -1115,7 +1078,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/dotgitignore/-/dotgitignore-1.0.3.tgz",
       "integrity": "sha512-eu5XjSstm0WXQsARgo6kPjkINYZlOUW+z/KtAAIBjHa5mUpMPrxJytbPIndWz6GubBuuuH5ljtVcXKnVnH5q8w==",
-      "dev": true,
       "requires": {
         "find-up": "2.1.0",
         "minimatch": "3.0.4"
@@ -1393,7 +1355,7 @@
     "espree": {
       "version": "3.5.2",
       "resolved": "https://registry.npmjs.org/espree/-/espree-3.5.2.tgz",
-      "integrity": "sha1-dWrai5eenc/NswqtjRqTBKkF4co=",
+      "integrity": "sha512-sadKeYwaR/aJ3stC2CdvgXu1T16TdYN+qwCpcWbMnGJ8s0zNWemzrvb2GbD4OhmJ/fwpJjudThAlLobGbWZbCQ==",
       "dev": true,
       "requires": {
         "acorn": "5.3.0",
@@ -1403,7 +1365,7 @@
     "esprima": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
-      "integrity": "sha1-RJnt3NERDgshi6zy+n9/WfVcqAQ="
+      "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw=="
     },
     "esquery": {
       "version": "1.0.0",
@@ -1448,7 +1410,6 @@
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
       "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
-      "dev": true,
       "requires": {
         "cross-spawn": "5.1.0",
         "get-stream": "3.0.0",
@@ -1581,7 +1542,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/formatio/-/formatio-1.2.0.tgz",
       "integrity": "sha1-87IWfZBoxGmKjVH092CjmlTYGOs=",
-      "dev": true,
       "requires": {
         "samsam": "1.3.0"
       }
@@ -1590,7 +1550,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/fs-access/-/fs-access-1.0.1.tgz",
       "integrity": "sha1-1qh/JiJxzv6+wwxVNAf7mV2od3o=",
-      "dev": true,
       "requires": {
         "null-check": "1.0.0"
       }
@@ -1611,7 +1570,7 @@
     },
     "fstream": {
       "version": "0.1.31",
-      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/fstream/-/fstream-0.1.31.tgz",
+      "resolved": "https://registry.npmjs.org/fstream/-/fstream-0.1.31.tgz",
       "integrity": "sha1-czfwWPu7vvqMn1YaKMqwhJICyYg=",
       "requires": {
         "graceful-fs": "3.0.11",
@@ -1622,7 +1581,7 @@
       "dependencies": {
         "graceful-fs": {
           "version": "3.0.11",
-          "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/graceful-fs/-/graceful-fs-3.0.11.tgz",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.11.tgz",
           "integrity": "sha1-dhPHeKGv6mLyXGMKCG1/Osu92Bg=",
           "requires": {
             "natives": "1.1.1"
@@ -1664,9 +1623,9 @@
       }
     },
     "generator-ibm-java-liberty": {
-      "version": "8.0.0",
-      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/generator-ibm-java-liberty/-/generator-ibm-java-liberty-8.0.0.tgz",
-      "integrity": "sha1-m79/9XRSIgLe1nydHQvHBls62lI=",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/generator-ibm-java-liberty/-/generator-ibm-java-liberty-8.0.1.tgz",
+      "integrity": "sha1-zlKVxT5VNUuNo/IEy46baq9e9To=",
       "requires": {
         "bluebird": "3.5.1",
         "extend": "3.0.1",
@@ -1674,13 +1633,14 @@
         "ibm-java-codegen-common": "3.0.0",
         "request": "2.83.0",
         "unzip2": "0.2.5",
+        "yeoman-assert": "2.2.3",
         "yeoman-generator": "1.1.1"
       }
     },
     "generator-ibm-java-spring": {
-      "version": "2.0.0",
-      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/generator-ibm-java-spring/-/generator-ibm-java-spring-2.0.0.tgz",
-      "integrity": "sha1-8leRFa5aYee6uMLwseKPEbh1LtE=",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/generator-ibm-java-spring/-/generator-ibm-java-spring-2.0.1.tgz",
+      "integrity": "sha1-XGoZjNEY/wxwAwuonoPhmBcCPdA=",
       "requires": {
         "bluebird": "3.5.1",
         "extend": "3.0.1",
@@ -1688,13 +1648,14 @@
         "ibm-java-codegen-common": "3.0.0",
         "request": "2.83.0",
         "unzip2": "0.2.5",
+        "yeoman-assert": "2.2.3",
         "yeoman-generator": "1.1.1"
       }
     },
     "generator-ibm-service-enablement": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/generator-ibm-service-enablement/-/generator-ibm-service-enablement-0.6.0.tgz",
-      "integrity": "sha1-+/sw2PvVGspWfAbloDiFbsvcYTg=",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/generator-ibm-service-enablement/-/generator-ibm-service-enablement-0.7.0.tgz",
+      "integrity": "sha512-tcUdgeeXf0kDBbMIzbpNt3EPjmK3KlMYLYwfWt3eVv64x0Dp8nIATmgAqyB7GE4AZbH3Xm7h/jvo8nL3LDLlEw==",
       "requires": {
         "handlebars": "4.0.11",
         "lodash": "4.17.4",
@@ -1705,7 +1666,7 @@
     "generator-ibm-usecase-enablement": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/generator-ibm-usecase-enablement/-/generator-ibm-usecase-enablement-3.0.0.tgz",
-      "integrity": "sha1-YrVpWsJ/k12JNZPdtG11jpTja3g=",
+      "integrity": "sha512-vkQOWGcywXv1Me+fgDh3I0Uud5TH4jL0S6QJ9W+lNqGwNy4iehnn3ppTqL5JZpSEdls5TMn4gUV9c96MxyvOJw==",
       "requires": {
         "glob": "7.1.2",
         "guid": "0.0.12",
@@ -1722,14 +1683,12 @@
     "get-caller-file": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
-      "integrity": "sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U=",
-      "dev": true
+      "integrity": "sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U="
     },
     "get-pkg-repo": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/get-pkg-repo/-/get-pkg-repo-1.4.0.tgz",
       "integrity": "sha1-xztInAbYDMVTbCyFP54FIyBWly0=",
-      "dev": true,
       "requires": {
         "hosted-git-info": "2.5.0",
         "meow": "3.7.0",
@@ -1741,8 +1700,7 @@
     "get-stdin": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
-      "integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4=",
-      "dev": true
+      "integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4="
     },
     "get-stream": {
       "version": "3.0.0",
@@ -1770,7 +1728,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/git-raw-commits/-/git-raw-commits-1.3.0.tgz",
       "integrity": "sha1-C8hZbpDV/+c29/VUa9LRL3OrqsY=",
-      "dev": true,
       "requires": {
         "dargs": "4.1.0",
         "lodash.template": "4.4.0",
@@ -1783,7 +1740,6 @@
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/dargs/-/dargs-4.1.0.tgz",
           "integrity": "sha1-A6nbtLXC8Tm/FK5T8LiipqhvThc=",
-          "dev": true,
           "requires": {
             "number-is-nan": "1.0.1"
           }
@@ -1794,7 +1750,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/git-remote-origin-url/-/git-remote-origin-url-2.0.0.tgz",
       "integrity": "sha1-UoJlna4hBxRaERJhEq0yFuxfpl8=",
-      "dev": true,
       "requires": {
         "gitconfiglocal": "1.0.0",
         "pify": "2.3.0"
@@ -1804,7 +1759,6 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/git-semver-tags/-/git-semver-tags-1.2.3.tgz",
       "integrity": "sha1-GItFOIK/nXojr9Mbq6U32rc4jV0=",
-      "dev": true,
       "requires": {
         "meow": "3.7.0",
         "semver": "5.4.1"
@@ -1814,7 +1768,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/gitconfiglocal/-/gitconfiglocal-1.0.0.tgz",
       "integrity": "sha1-QdBF84UaXqiPA/JMocYXgRRGS5s=",
-      "dev": true,
       "requires": {
         "ini": "1.3.5"
       }
@@ -1830,7 +1783,7 @@
     "glob": {
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-      "integrity": "sha1-wZyd+aAocC1nhhI4SmVSQExjbRU=",
+      "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
       "requires": {
         "fs.realpath": "1.0.0",
         "inflight": "1.0.6",
@@ -1843,7 +1796,7 @@
     "globals": {
       "version": "11.1.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-11.1.0.tgz",
-      "integrity": "sha1-YyZERX9fDjrnEYBxg3AOvy5GM+Q=",
+      "integrity": "sha512-uEuWt9mqTlPDwSqi+sHjD4nWU/1N+q0fiWI9T1mZpD2UENqX20CFD5T/ziLZvztPaBKl7ZylUi1q6Qfm7E2CiQ==",
       "dev": true
     },
     "globby": {
@@ -1949,13 +1902,12 @@
     "has-flag": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
-      "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
-      "dev": true
+      "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE="
     },
     "hawk": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/hawk/-/hawk-6.0.2.tgz",
-      "integrity": "sha1-r02RTrBl+bXOTZ0RwcshJu7MMDg=",
+      "integrity": "sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==",
       "requires": {
         "boom": "4.3.1",
         "cryptiles": "3.1.2",
@@ -1972,12 +1924,12 @@
     "hoek": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.0.tgz",
-      "integrity": "sha1-ctnQdU9/4lyi0BrY+PmpRJqJUm0="
+      "integrity": "sha512-v0XCLxICi9nPfYrS9RL8HbYnXi9obYAeLbSP00BmnZwCK9+Ih9WOjoZ8YoHCoav2csqn4FOz4Orldsy2dmDwmQ=="
     },
     "hosted-git-info": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.5.0.tgz",
-      "integrity": "sha1-bWDjSzq7yDEwYsO3mO+NkBoHrzw="
+      "integrity": "sha512-pNgbURSuab90KbTqvRPsseaTxOJCZBD0a7t+haSN33piP9cCM4l0CqdzAif2hUqm716UovKB2ROmiabGAKVXyg=="
     },
     "http-signature": {
       "version": "1.2.0",
@@ -2001,13 +1953,12 @@
     "iconv-lite": {
       "version": "0.4.19",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
-      "integrity": "sha1-90aPYBNfXl2tM5nAqBvpoWA6CCs=",
-      "dev": true
+      "integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ=="
     },
     "ignore": {
       "version": "3.3.7",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.7.tgz",
-      "integrity": "sha1-YSKJv7PCIOGGpYEYYY1b6MG6sCE=",
+      "integrity": "sha512-YGG3ejvBNHRqu0559EOxxNFihD0AjpvHlC/pdGKd3X3ofe+CoJkYazwNJYTNebqpPKN+VVQbh4ZFn1DivMNuHA==",
       "dev": true
     },
     "imurmurhash": {
@@ -2020,7 +1971,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
       "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
-      "dev": true,
       "requires": {
         "repeating": "2.0.1"
       }
@@ -2042,8 +1992,7 @@
     "ini": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
-      "integrity": "sha1-7uJfVtscnsYIXgwid4CD9Zar+Sc=",
-      "dev": true
+      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
     },
     "inquirer": {
       "version": "1.2.3",
@@ -2074,8 +2023,7 @@
     "invert-kv": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
-      "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
-      "dev": true
+      "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY="
     },
     "is-arrayish": {
       "version": "0.2.1",
@@ -2085,7 +2033,7 @@
     "is-buffer": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-      "integrity": "sha1-76ouqdqg16suoTqXsritUf776L4="
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
     },
     "is-builtin-module": {
       "version": "1.0.0",
@@ -2099,7 +2047,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
       "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
-      "dev": true,
       "requires": {
         "number-is-nan": "1.0.1"
       }
@@ -2127,8 +2074,7 @@
     "is-obj": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
-      "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
-      "dev": true
+      "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8="
     },
     "is-path-cwd": {
       "version": "1.0.0",
@@ -2178,7 +2124,7 @@
     "is-resolvable": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.0.1.tgz",
-      "integrity": "sha1-rMoc022+RLl0uSQyFVWnC6A7HPQ=",
+      "integrity": "sha512-y5CXYbzvB3jTnWAZH1Nl7ykUWb6T3BcTs56HUruwBf8MhF56n1HWqhDWnVFo8GHrUPDgvUUNVhrc2U8W7iqz5g==",
       "dev": true
     },
     "is-retry-allowed": {
@@ -2190,7 +2136,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-scoped/-/is-scoped-1.0.0.tgz",
       "integrity": "sha1-RJypgpnnEwOCViieyytUDcQ3yzA=",
-      "dev": true,
       "requires": {
         "scoped-regex": "1.0.0"
       }
@@ -2203,14 +2148,12 @@
     "is-subset": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/is-subset/-/is-subset-0.1.1.tgz",
-      "integrity": "sha1-ilkRfZMt4d4A8kX83TnOQ/HpOaY=",
-      "dev": true
+      "integrity": "sha1-ilkRfZMt4d4A8kX83TnOQ/HpOaY="
     },
     "is-text-path": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-text-path/-/is-text-path-1.0.1.tgz",
       "integrity": "sha1-Thqg+1G/vLPpJogAE5cgLBd1tm4=",
-      "dev": true,
       "requires": {
         "text-extensions": "1.7.0"
       }
@@ -2259,7 +2202,7 @@
     "js-yaml": {
       "version": "3.10.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.10.0.tgz",
-      "integrity": "sha1-LnhEFka9RoLpY/IrbpKCPDCcYtw=",
+      "integrity": "sha512-O2v52ffjLa9VeM43J4XocZE//WT9N0IiwDa3KSHH7Tu8CtH+1qM8SIZvnsTh6v+4yFy5KUY3BHUVwjpfAWsjIA==",
       "requires": {
         "argparse": "1.0.9",
         "esprima": "4.0.0"
@@ -2309,8 +2252,7 @@
     "jsonparse": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
-      "integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA=",
-      "dev": true
+      "integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA="
     },
     "jsonpointer": {
       "version": "4.0.1",
@@ -2347,7 +2289,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
       "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
-      "dev": true,
       "requires": {
         "invert-kv": "1.0.0"
       }
@@ -2430,8 +2371,7 @@
     "lodash._reinterpolate": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
-      "integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0=",
-      "dev": true
+      "integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0="
     },
     "lodash.create": {
       "version": "3.1.1",
@@ -2471,7 +2411,6 @@
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-4.4.0.tgz",
       "integrity": "sha1-5zoDhcg1VZF0bgILmWecaQ5o+6A=",
-      "dev": true,
       "requires": {
         "lodash._reinterpolate": "3.0.0",
         "lodash.templatesettings": "4.1.0"
@@ -2481,7 +2420,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-4.1.0.tgz",
       "integrity": "sha1-K01OlbpEDZFf8IvImeRVNmZxMxY=",
-      "dev": true,
       "requires": {
         "lodash._reinterpolate": "3.0.0"
       }
@@ -2513,8 +2451,7 @@
     "lolex": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/lolex/-/lolex-1.6.0.tgz",
-      "integrity": "sha1-OpoCg0UqR9dDnnJzG54H1zhuSfY=",
-      "dev": true
+      "integrity": "sha1-OpoCg0UqR9dDnnJzG54H1zhuSfY="
     },
     "longest": {
       "version": "1.0.1",
@@ -2525,7 +2462,6 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
       "integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
-      "dev": true,
       "requires": {
         "currently-unhandled": "0.4.1",
         "signal-exit": "3.0.2"
@@ -2539,7 +2475,7 @@
     "lru-cache": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
-      "integrity": "sha1-Yi4y6CSItJJ5EUpPns9F581rulU=",
+      "integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
       "requires": {
         "pseudomap": "1.0.2",
         "yallist": "2.1.2"
@@ -2548,12 +2484,11 @@
     "map-obj": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
-      "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
-      "dev": true
+      "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0="
     },
     "match-stream": {
       "version": "0.0.2",
-      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/match-stream/-/match-stream-0.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/match-stream/-/match-stream-0.0.2.tgz",
       "integrity": "sha1-mesFAJOzTf+t5CG5rAtBCpz6F88=",
       "requires": {
         "buffers": "0.1.1",
@@ -2562,12 +2497,12 @@
       "dependencies": {
         "isarray": {
           "version": "0.0.1",
-          "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/isarray/-/isarray-0.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
           "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
         },
         "readable-stream": {
           "version": "1.0.34",
-          "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/readable-stream/-/readable-stream-1.0.34.tgz",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
           "requires": {
             "core-util-is": "1.0.2",
@@ -2578,7 +2513,7 @@
         },
         "string_decoder": {
           "version": "0.10.31",
-          "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/string_decoder/-/string_decoder-0.10.31.tgz",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
           "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
         }
       }
@@ -2587,7 +2522,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
       "integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
-      "dev": true,
       "requires": {
         "mimic-fn": "1.1.0"
       }
@@ -2650,7 +2584,6 @@
       "version": "3.7.0",
       "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
       "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
-      "dev": true,
       "requires": {
         "camelcase-keys": "2.1.0",
         "decamelize": "1.2.0",
@@ -2668,7 +2601,6 @@
           "version": "1.1.2",
           "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
           "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
-          "dev": true,
           "requires": {
             "path-exists": "2.1.0",
             "pinkie-promise": "2.0.1"
@@ -2678,7 +2610,6 @@
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
           "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
-          "dev": true,
           "requires": {
             "graceful-fs": "4.1.11",
             "parse-json": "2.2.0",
@@ -2690,20 +2621,17 @@
         "minimist": {
           "version": "1.2.0",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-          "dev": true
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
         },
         "object-assign": {
           "version": "4.1.1",
           "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-          "dev": true
+          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
         },
         "path-exists": {
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
           "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
-          "dev": true,
           "requires": {
             "pinkie-promise": "2.0.1"
           }
@@ -2712,7 +2640,6 @@
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
           "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
-          "dev": true,
           "requires": {
             "graceful-fs": "4.1.11",
             "pify": "2.3.0",
@@ -2723,7 +2650,6 @@
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
           "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
-          "dev": true,
           "requires": {
             "load-json-file": "1.1.0",
             "normalize-package-data": "2.4.0",
@@ -2734,7 +2660,6 @@
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
           "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
-          "dev": true,
           "requires": {
             "find-up": "1.1.2",
             "read-pkg": "1.1.0"
@@ -2744,7 +2669,6 @@
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
           "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
-          "dev": true,
           "requires": {
             "is-utf8": "0.2.1"
           }
@@ -2767,13 +2691,12 @@
     "mimic-fn": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.1.0.tgz",
-      "integrity": "sha1-5md4PZLonb00KBi1IwudYqZyrRg=",
-      "dev": true
+      "integrity": "sha1-5md4PZLonb00KBi1IwudYqZyrRg="
     },
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "requires": {
         "brace-expansion": "1.1.8"
       }
@@ -2801,7 +2724,7 @@
     "mocha": {
       "version": "3.5.3",
       "resolved": "https://registry.npmjs.org/mocha/-/mocha-3.5.3.tgz",
-      "integrity": "sha1-HgSA/jbS2lhY0etqzDhBiybqog0=",
+      "integrity": "sha512-/6na001MJWEtYxHOV1WLfsmR4YIynkUEhBwzsb+fk2qmQ3iqsi258l/Q2MWHJMImAcNpZ8DEdYAK72NHoIQ9Eg==",
       "dev": true,
       "requires": {
         "browser-stdout": "1.3.0",
@@ -2876,8 +2799,7 @@
     "modify-values": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/modify-values/-/modify-values-1.0.0.tgz",
-      "integrity": "sha1-4rbN65zhn5kxelNyLz2/XfXqqrI=",
-      "dev": true
+      "integrity": "sha1-4rbN65zhn5kxelNyLz2/XfXqqrI="
     },
     "ms": {
       "version": "2.0.0",
@@ -2903,8 +2825,7 @@
     "native-promise-only": {
       "version": "0.8.1",
       "resolved": "https://registry.npmjs.org/native-promise-only/-/native-promise-only-0.8.1.tgz",
-      "integrity": "sha1-IKMYwwy0X3H+et+/eyHJnBRy7xE=",
-      "dev": true
+      "integrity": "sha1-IKMYwwy0X3H+et+/eyHJnBRy7xE="
     },
     "natives": {
       "version": "1.1.1",
@@ -2920,7 +2841,7 @@
     "normalize-package-data": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
-      "integrity": "sha1-EvlaMH1YNSB1oEkHuErIvpisAS8=",
+      "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
       "requires": {
         "hosted-git-info": "2.5.0",
         "is-builtin-module": "1.0.0",
@@ -2932,7 +2853,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
       "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
-      "dev": true,
       "requires": {
         "path-key": "2.0.1"
       }
@@ -2940,8 +2860,7 @@
     "null-check": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/null-check/-/null-check-1.0.0.tgz",
-      "integrity": "sha1-l33/1xdgErnsMNKjnbXPcqBDnt0=",
-      "dev": true
+      "integrity": "sha1-l33/1xdgErnsMNKjnbXPcqBDnt0="
     },
     "number-is-nan": {
       "version": "1.0.1",
@@ -4604,8 +4523,7 @@
     "os-locale": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
-      "integrity": "sha1-QrwpAKa1uL0XN2yOiCtlr8zyS/I=",
-      "dev": true,
+      "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
       "requires": {
         "execa": "0.7.0",
         "lcid": "1.0.0",
@@ -4624,14 +4542,13 @@
     },
     "over": {
       "version": "0.0.5",
-      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/over/-/over-0.0.5.tgz",
+      "resolved": "https://registry.npmjs.org/over/-/over-0.0.5.tgz",
       "integrity": "sha1-8phS5w/X4l82DgE6jsRMgq7bVwg="
     },
     "p-finally": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
-      "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
-      "dev": true
+      "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
     },
     "p-limit": {
       "version": "1.1.0",
@@ -4649,8 +4566,7 @@
     "parse-github-repo-url": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/parse-github-repo-url/-/parse-github-repo-url-1.4.1.tgz",
-      "integrity": "sha1-nn2LslKmy2ukJZUGC3v23z28H1A=",
-      "dev": true
+      "integrity": "sha1-nn2LslKmy2ukJZUGC3v23z28H1A="
     },
     "parse-json": {
       "version": "2.2.0",
@@ -4679,8 +4595,7 @@
     "path-key": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
-      "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
-      "dev": true
+      "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A="
     },
     "path-parse": {
       "version": "1.0.5",
@@ -4691,7 +4606,6 @@
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.7.0.tgz",
       "integrity": "sha1-Wf3g9DW62suhA6hOnTvGTpa5k30=",
-      "dev": true,
       "requires": {
         "isarray": "0.0.1"
       },
@@ -4699,8 +4613,7 @@
         "isarray": {
           "version": "0.0.1",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-          "dev": true
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
         }
       }
     },
@@ -4738,7 +4651,7 @@
     "pluralize": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-7.0.0.tgz",
-      "integrity": "sha1-KYuJ34uTsCIdv0Ia0rGx6iP8Z3c=",
+      "integrity": "sha512-ARhBOdzS3e41FbkW/XWrTEtukqqLoK5+Z/4UeDaLuSW+39JPeFgs4gCGqsrJHVZX0fUrx//4OF0K1CUGwlIFow==",
       "dev": true
     },
     "prelude-ls": {
@@ -4775,7 +4688,7 @@
     },
     "pullstream": {
       "version": "0.4.1",
-      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/pullstream/-/pullstream-0.4.1.tgz",
+      "resolved": "https://registry.npmjs.org/pullstream/-/pullstream-0.4.1.tgz",
       "integrity": "sha1-1vs79a7Wl+gxFQ6xACwlo/iuExQ=",
       "requires": {
         "over": "0.0.5",
@@ -4786,12 +4699,12 @@
       "dependencies": {
         "isarray": {
           "version": "0.0.1",
-          "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/isarray/-/isarray-0.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
           "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
         },
         "readable-stream": {
           "version": "1.0.34",
-          "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/readable-stream/-/readable-stream-1.0.34.tgz",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
           "requires": {
             "core-util-is": "1.0.2",
@@ -4802,7 +4715,7 @@
         },
         "string_decoder": {
           "version": "0.10.31",
-          "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/string_decoder/-/string_decoder-0.10.31.tgz",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
           "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
         }
       }
@@ -4820,7 +4733,7 @@
     "qs": {
       "version": "6.5.1",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
-      "integrity": "sha1-NJzfbu+J7EXBLX1es/wMhwNDptg="
+      "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A=="
     },
     "read-chunk": {
       "version": "2.1.0",
@@ -4860,7 +4773,7 @@
     "readable-stream": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
-      "integrity": "sha1-No8lEtefnUb9/HE0mueHi7weuVw=",
+      "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
       "requires": {
         "core-util-is": "1.0.2",
         "inherits": "2.0.3",
@@ -4883,7 +4796,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
       "integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
-      "dev": true,
       "requires": {
         "indent-string": "2.1.0",
         "strip-indent": "1.0.1"
@@ -4903,7 +4815,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
       "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
-      "dev": true,
       "requires": {
         "is-finite": "1.0.2"
       }
@@ -4916,7 +4827,7 @@
     "request": {
       "version": "2.83.0",
       "resolved": "https://registry.npmjs.org/request/-/request-2.83.0.tgz",
-      "integrity": "sha1-ygtl2gLtYpNYh4COb1EDgQNOM1Y=",
+      "integrity": "sha512-lR3gD69osqm6EYLk9wB/G1W/laGWjzH90t1vEa2xuxHD5KUrSzp9pUSfTm+YC5Nxt2T8nMPEvKlhbQayU7bgFw==",
       "requires": {
         "aws-sign2": "0.7.0",
         "aws4": "1.6.0",
@@ -4945,14 +4856,12 @@
     "require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
-      "dev": true
+      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
     },
     "require-main-filename": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
-      "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
-      "dev": true
+      "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE="
     },
     "require-uncached": {
       "version": "1.0.3",
@@ -4967,7 +4876,7 @@
     "resolve": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.5.0.tgz",
-      "integrity": "sha1-HwmsznlsmnYlefMbLBzEw83fnzY=",
+      "integrity": "sha512-hgoSGrc3pjzAPHNBg+KnFcK2HwlHTs/YrAGUr6qgTVUZmXv1UEXXl0bZNBKMA9fud6lRYFdPGz0xXxycPzmmiw==",
       "requires": {
         "path-parse": "1.0.5"
       }
@@ -4999,7 +4908,7 @@
     "rimraf": {
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
-      "integrity": "sha1-LtgVDSShbqhlHm1u8PR8QVjOejY=",
+      "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
       "requires": {
         "glob": "7.1.2"
       }
@@ -5020,14 +4929,12 @@
     "rx-lite": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-4.0.8.tgz",
-      "integrity": "sha1-Cx4Rr4vESDbwSmQH6S2kJGe3lEQ=",
-      "dev": true
+      "integrity": "sha1-Cx4Rr4vESDbwSmQH6S2kJGe3lEQ="
     },
     "rx-lite-aggregates": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/rx-lite-aggregates/-/rx-lite-aggregates-4.0.8.tgz",
       "integrity": "sha1-dTuHqJoRyVRnxKwWJsTvxOBcZ74=",
-      "dev": true,
       "requires": {
         "rx-lite": "4.0.8"
       }
@@ -5035,34 +4942,31 @@
     "safe-buffer": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-      "integrity": "sha1-iTMSr2myEj3vcfV4iQAWce6yyFM="
+      "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
     },
     "samsam": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/samsam/-/samsam-1.3.0.tgz",
-      "integrity": "sha1-jR2TUOJWItow3j5EumkrUiGrfFA=",
-      "dev": true
+      "integrity": "sha512-1HwIYD/8UlOtFS3QO3w7ey+SdSDFE4HRNLZoZRYVQefrOY3l17epswImeB1ijgJFQJodIaHcwkp3r/myBjFVbg=="
     },
     "scoped-regex": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/scoped-regex/-/scoped-regex-1.0.0.tgz",
-      "integrity": "sha1-o0a7Gs1CB65wvXwMfKnlZra63bg=",
-      "dev": true
+      "integrity": "sha1-o0a7Gs1CB65wvXwMfKnlZra63bg="
     },
     "semver": {
       "version": "5.4.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
-      "integrity": "sha1-4FnAnYVx8FQII3M0M1BdOi8AsY4="
+      "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg=="
     },
     "set-blocking": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
-      "dev": true
+      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
     },
     "setimmediate": {
       "version": "1.0.5",
-      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/setimmediate/-/setimmediate-1.0.5.tgz",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
       "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU="
     },
     "shebang-command": {
@@ -5091,14 +4995,12 @@
     "signal-exit": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
-      "dev": true
+      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
     },
     "sinon": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/sinon/-/sinon-2.4.1.tgz",
-      "integrity": "sha1-Ah/WS1TLd9nS+w1Dze3652KcOjY=",
-      "dev": true,
+      "integrity": "sha512-vFTrO9Wt0ECffDYIPSP/E5bBugt0UjcBQOfQUMh66xzkyPEnhl/vM2LRZi2ajuTdkH07sA6DzrM6KvdvGIH8xw==",
       "requires": {
         "diff": "3.4.0",
         "formatio": "1.2.0",
@@ -5113,15 +5015,14 @@
         "diff": {
           "version": "3.4.0",
           "resolved": "https://registry.npmjs.org/diff/-/diff-3.4.0.tgz",
-          "integrity": "sha1-sdhVB9rzlkgo3lSzfQ1zumfdpWw=",
-          "dev": true
+          "integrity": "sha512-QpVuMTEoJMF7cKzi6bvWhRulU1fZqZnvyVQgNhPaxxuTYwyjn/j1v9falseQ/uXWwPnO56RBfwtg4h/EQXmucA=="
         }
       }
     },
     "slice-ansi": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-1.0.0.tgz",
-      "integrity": "sha1-BE8aSdiEL/MHqta1Be0Xi9lQE00=",
+      "integrity": "sha512-POqxBK6Lb3q6s047D/XsDVNPnF9Dl8JSaqe9h9lURl0OdNqy/ujDrOiIHtsqXMGbWWTIomRzAMaTyawAU//Reg==",
       "dev": true,
       "requires": {
         "is-fullwidth-code-point": "2.0.0"
@@ -5137,7 +5038,7 @@
     },
     "slice-stream": {
       "version": "1.0.0",
-      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/slice-stream/-/slice-stream-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/slice-stream/-/slice-stream-1.0.0.tgz",
       "integrity": "sha1-WzO9ZvATsaf4ZGCwPUY97DmtPqA=",
       "requires": {
         "readable-stream": "1.0.34"
@@ -5145,12 +5046,12 @@
       "dependencies": {
         "isarray": {
           "version": "0.0.1",
-          "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/isarray/-/isarray-0.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
           "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
         },
         "readable-stream": {
           "version": "1.0.34",
-          "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/readable-stream/-/readable-stream-1.0.34.tgz",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
           "requires": {
             "core-util-is": "1.0.2",
@@ -5161,7 +5062,7 @@
         },
         "string_decoder": {
           "version": "0.10.31",
-          "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/string_decoder/-/string_decoder-0.10.31.tgz",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
           "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
         }
       }
@@ -5169,7 +5070,7 @@
     "sntp": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/sntp/-/sntp-2.1.0.tgz",
-      "integrity": "sha1-LGzsFP7cIiJznK+bXD2F0cxaLMg=",
+      "integrity": "sha512-FL1b58BDrqS3A11lJ0zEdnJ3UOKqVxawAkF3k7F0CVN7VQ34aZrV+G8BZ1WC9ZL7NyrwsW0oviwsWDgRuVYtJg==",
       "requires": {
         "hoek": "4.2.0"
       }
@@ -5212,8 +5113,7 @@
     "split": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
-      "integrity": "sha1-YFvZvjA6pZ+zX5Ip++oN3snqB9k=",
-      "dev": true,
+      "integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
       "requires": {
         "through": "2.3.8"
       }
@@ -5221,8 +5121,7 @@
     "split2": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/split2/-/split2-2.2.0.tgz",
-      "integrity": "sha1-GGsldbz4PoW30YRldWI47k7kJJM=",
-      "dev": true,
+      "integrity": "sha512-RAb22TG39LhI31MbreBgIuKiIKhVsawfTgEGqKHTK87aG+ul/PB8Sqoi3I7kVdRWiCfrKxK3uo4/YUkpNvhPbw==",
       "requires": {
         "through2": "2.0.3"
       }
@@ -5251,7 +5150,6 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/standard-version/-/standard-version-4.3.0.tgz",
       "integrity": "sha512-2UJ2BIUNa7+41PH4FvYicSQED2LCt2RXjmNFis+JZlxZtwzNnGn4uuL8WBUqHoC9b+bJ0AHIAX/bilzm+pGPeA==",
-      "dev": true,
       "requires": {
         "chalk": "1.1.3",
         "conventional-changelog": "1.1.7",
@@ -5303,7 +5201,6 @@
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
           "integrity": "sha1-q5Pyeo3BPSjKyBXEYhQ6bZASrp4=",
-          "dev": true,
           "requires": {
             "is-fullwidth-code-point": "2.0.0",
             "strip-ansi": "4.0.0"
@@ -5406,7 +5303,7 @@
     "string_decoder": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-      "integrity": "sha1-D8Z9fBQYJd6UKC3VNr7GubzoYKs=",
+      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
       "requires": {
         "safe-buffer": "5.1.1"
       }
@@ -5451,14 +5348,12 @@
     "strip-eof": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
-      "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
-      "dev": true
+      "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8="
     },
     "strip-indent": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
       "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
-      "dev": true,
       "requires": {
         "get-stdin": "4.0.1"
       }
@@ -5477,7 +5372,7 @@
     "table": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/table/-/table-4.0.2.tgz",
-      "integrity": "sha1-ozRHN1OR52atNNNIbm4q7chNLjY=",
+      "integrity": "sha512-UUkEAPdSGxtRpiV9ozJ5cMTtYiqz7Ni1OGqLXRCynrvzdtR1p+cfOWe2RJLwvUG8hNanaSRjecIqwOjqeatDsA==",
       "dev": true,
       "requires": {
         "ajv": "5.5.2",
@@ -5497,7 +5392,7 @@
         "ansi-styles": {
           "version": "3.2.0",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
-          "integrity": "sha1-wVm41b4PnlpvNG2rlPFs4CIWG4g=",
+          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
           "dev": true,
           "requires": {
             "color-convert": "1.9.1"
@@ -5506,7 +5401,7 @@
         "chalk": {
           "version": "2.3.0",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
-          "integrity": "sha1-tepI78nBeT3MybR2fJORTT8tUro=",
+          "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
           "dev": true,
           "requires": {
             "ansi-styles": "3.2.0",
@@ -5523,7 +5418,7 @@
         "string-width": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-          "integrity": "sha1-q5Pyeo3BPSjKyBXEYhQ6bZASrp4=",
+          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
           "dev": true,
           "requires": {
             "is-fullwidth-code-point": "2.0.0",
@@ -5553,14 +5448,12 @@
     "text-encoding": {
       "version": "0.6.4",
       "resolved": "https://registry.npmjs.org/text-encoding/-/text-encoding-0.6.4.tgz",
-      "integrity": "sha1-45mpgiV6J22uQou5KEXLcb3CbRk=",
-      "dev": true
+      "integrity": "sha1-45mpgiV6J22uQou5KEXLcb3CbRk="
     },
     "text-extensions": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/text-extensions/-/text-extensions-1.7.0.tgz",
-      "integrity": "sha1-+qq6JiXtdG1WiiPk0KrNm/CKizk=",
-      "dev": true
+      "integrity": "sha512-AKXZeDq230UaSzaO5s3qQUZOaC7iKbzq0jOFL614R7d9R593HLqAOL0cYoqLdkNrjBSOdmoQI06yigq1TSBXAg=="
     },
     "text-table": {
       "version": "0.2.0",
@@ -5609,20 +5502,18 @@
     },
     "traverse": {
       "version": "0.3.9",
-      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/traverse/-/traverse-0.3.9.tgz",
+      "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.3.9.tgz",
       "integrity": "sha1-cXuPIgzAu3tE5AUUwisui7xw2Lk="
     },
     "trim-newlines": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
-      "integrity": "sha1-WIeWa7WCpFA6QetST301ARgVphM=",
-      "dev": true
+      "integrity": "sha1-WIeWa7WCpFA6QetST301ARgVphM="
     },
     "trim-off-newlines": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/trim-off-newlines/-/trim-off-newlines-1.0.1.tgz",
-      "integrity": "sha1-n5up2e+odkw4dpi8v+sshI8RrbM=",
-      "dev": true
+      "integrity": "sha1-n5up2e+odkw4dpi8v+sshI8RrbM="
     },
     "tunnel-agent": {
       "version": "0.6.0",
@@ -5650,8 +5541,7 @@
     "type-detect": {
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.5.tgz",
-      "integrity": "sha1-1w5byB223io4G8rKDG4MvcdjXeI=",
-      "dev": true
+      "integrity": "sha512-N9IvkQslUGYGC24RkJk1ba99foK6TkwC2FHAEBlQFBP0RxQZS8ZpJuAZcwiY/w9ZJHFQb1aOXBI60OdxhTrwEQ=="
     },
     "typedarray": {
       "version": "0.0.6",
@@ -5698,7 +5588,7 @@
     },
     "unzip2": {
       "version": "0.2.5",
-      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/unzip2/-/unzip2-0.2.5.tgz",
+      "resolved": "https://registry.npmjs.org/unzip2/-/unzip2-0.2.5.tgz",
       "integrity": "sha1-TveleaeMFcUfVQ9qBT2xlBSciZI=",
       "requires": {
         "binary": "0.3.0",
@@ -5711,12 +5601,12 @@
       "dependencies": {
         "isarray": {
           "version": "0.0.1",
-          "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/isarray/-/isarray-0.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
           "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
         },
         "readable-stream": {
           "version": "1.0.34",
-          "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/readable-stream/-/readable-stream-1.0.34.tgz",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
           "requires": {
             "core-util-is": "1.0.2",
@@ -5727,7 +5617,7 @@
         },
         "string_decoder": {
           "version": "0.10.31",
-          "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/string_decoder/-/string_decoder-0.10.31.tgz",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
           "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
         }
       }
@@ -5756,7 +5646,7 @@
     "uuid": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
-      "integrity": "sha1-PdPT55Crwk17DToDT/q6vijrvAQ="
+      "integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g=="
     },
     "validate-npm-package-license": {
       "version": "3.0.1",
@@ -5841,7 +5731,7 @@
     "which": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
-      "integrity": "sha1-/wS9/AEO5UfXgL7DjhrBwnd9JTo=",
+      "integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
       "requires": {
         "isexe": "2.0.0"
       }
@@ -5849,8 +5739,7 @@
     "which-module": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
-      "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
-      "dev": true
+      "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
     },
     "window-size": {
       "version": "0.1.0",
@@ -5867,7 +5756,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
       "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
-      "dev": true,
       "requires": {
         "string-width": "1.0.2",
         "strip-ansi": "3.0.1"
@@ -5895,8 +5783,7 @@
     "y18n": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
-      "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
-      "dev": true
+      "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE="
     },
     "yallist": {
       "version": "2.1.2",
@@ -5919,7 +5806,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-7.0.0.tgz",
       "integrity": "sha1-jQrELxbqVd69MyyvTEA4s+P139k=",
-      "dev": true,
       "requires": {
         "camelcase": "4.1.0"
       },
@@ -5927,16 +5813,14 @@
         "camelcase": {
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-          "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
-          "dev": true
+          "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
         }
       }
     },
     "yeoman-assert": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/yeoman-assert/-/yeoman-assert-2.2.3.tgz",
-      "integrity": "sha1-pWgqg2MsUKwO6EFzpaEP1vMgZHQ=",
-      "dev": true
+      "integrity": "sha1-pWgqg2MsUKwO6EFzpaEP1vMgZHQ="
     },
     "yeoman-environment": {
       "version": "1.6.6",
@@ -6029,7 +5913,7 @@
         "async": {
           "version": "2.6.0",
           "resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
-          "integrity": "sha1-YaKau2/MAm/qd+VtHG7FOnlZUfQ=",
+          "integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
           "requires": {
             "lodash": "4.17.4"
           }
@@ -6044,8 +5928,7 @@
     "yeoman-test": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/yeoman-test/-/yeoman-test-1.7.0.tgz",
-      "integrity": "sha1-PtvuZFkfJZcCeltCsdwFglGtyf4=",
-      "dev": true,
+      "integrity": "sha512-vJeg2gpWfhbq0HvQ7/yqmsQpYmADBfo9kaW+J6uJASkI7ChLBXNLIBQqaXCA65kWtHXOco+nBm0Km/O9YWk25Q==",
       "requires": {
         "inquirer": "3.3.0",
         "lodash": "4.17.4",
@@ -6060,20 +5943,17 @@
         "ansi-escapes": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.0.0.tgz",
-          "integrity": "sha1-7D6LTp+AZPwCw6ybZfHCdb2o75I=",
-          "dev": true
+          "integrity": "sha512-O/klc27mWNUigtv0F8NJWbLF00OcegQalkqKURWdosW08YZKi4m6CnSUSvIZG1otNJbTWhN01Hhz389DW7mvDQ=="
         },
         "ansi-regex": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-          "dev": true
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
         },
         "ansi-styles": {
           "version": "3.2.0",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
-          "integrity": "sha1-wVm41b4PnlpvNG2rlPFs4CIWG4g=",
-          "dev": true,
+          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
           "requires": {
             "color-convert": "1.9.1"
           }
@@ -6081,8 +5961,7 @@
         "chalk": {
           "version": "2.3.0",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
-          "integrity": "sha1-tepI78nBeT3MybR2fJORTT8tUro=",
-          "dev": true,
+          "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
           "requires": {
             "ansi-styles": "3.2.0",
             "escape-string-regexp": "1.0.5",
@@ -6093,7 +5972,6 @@
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
           "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
-          "dev": true,
           "requires": {
             "restore-cursor": "2.0.0"
           }
@@ -6101,8 +5979,7 @@
         "debug": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha1-W7WgZyYotkFJVmuhaBnmFRjGcmE=",
-          "dev": true,
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
           "requires": {
             "ms": "2.0.0"
           }
@@ -6110,14 +5987,12 @@
         "diff": {
           "version": "3.4.0",
           "resolved": "https://registry.npmjs.org/diff/-/diff-3.4.0.tgz",
-          "integrity": "sha1-sdhVB9rzlkgo3lSzfQ1zumfdpWw=",
-          "dev": true
+          "integrity": "sha512-QpVuMTEoJMF7cKzi6bvWhRulU1fZqZnvyVQgNhPaxxuTYwyjn/j1v9falseQ/uXWwPnO56RBfwtg4h/EQXmucA=="
         },
         "external-editor": {
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.1.0.tgz",
-          "integrity": "sha1-PQJqIbf5W1cmOH1CAKwWDTcsO0g=",
-          "dev": true,
+          "integrity": "sha512-E44iT5QVOUJBKij4IIV3uvxuNlbKS38Tw1HiupxEIHPv9qtC2PrDYohbXV5U+1jnfIXttny8gUhj+oZvflFlzA==",
           "requires": {
             "chardet": "0.4.2",
             "iconv-lite": "0.4.19",
@@ -6128,7 +6003,6 @@
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
           "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
-          "dev": true,
           "requires": {
             "escape-string-regexp": "1.0.5"
           }
@@ -6136,8 +6010,7 @@
         "inquirer": {
           "version": "3.3.0",
           "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.3.0.tgz",
-          "integrity": "sha1-ndLyrXZdyrH/BEO0kUQqILoifck=",
-          "dev": true,
+          "integrity": "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
           "requires": {
             "ansi-escapes": "3.0.0",
             "chalk": "2.3.0",
@@ -6158,14 +6031,12 @@
         "is-fullwidth-code-point": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-          "dev": true
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
         },
         "log-symbols": {
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-2.1.0.tgz",
-          "integrity": "sha1-81+mDieIMrU43E3dy7R4pF0+O+Y=",
-          "dev": true,
+          "integrity": "sha512-zLeLrzMA1A2vRF1e/0Mo+LNINzi6jzBylHj5WqvQ/WK/5WCZt8si9SyN4p9llr/HRYvVR1AoXHRHl4WTHyQAzQ==",
           "requires": {
             "chalk": "2.3.0"
           }
@@ -6173,14 +6044,12 @@
         "mute-stream": {
           "version": "0.0.7",
           "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
-          "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
-          "dev": true
+          "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s="
         },
         "onetime": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
           "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
-          "dev": true,
           "requires": {
             "mimic-fn": "1.1.0"
           }
@@ -6189,7 +6058,6 @@
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
           "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
-          "dev": true,
           "requires": {
             "onetime": "2.0.1",
             "signal-exit": "3.0.2"
@@ -6198,8 +6066,7 @@
         "string-width": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-          "integrity": "sha1-q5Pyeo3BPSjKyBXEYhQ6bZASrp4=",
-          "dev": true,
+          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
           "requires": {
             "is-fullwidth-code-point": "2.0.0",
             "strip-ansi": "4.0.0"
@@ -6209,7 +6076,6 @@
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-          "dev": true,
           "requires": {
             "ansi-regex": "3.0.0"
           }
@@ -6218,7 +6084,6 @@
           "version": "4.5.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
           "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
-          "dev": true,
           "requires": {
             "has-flag": "2.0.0"
           }
@@ -6226,8 +6091,7 @@
         "tmp": {
           "version": "0.0.33",
           "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
-          "integrity": "sha1-bTQzWIl2jSGyvNoKonfO07G/rfk=",
-          "dev": true,
+          "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
           "requires": {
             "os-tmpdir": "1.0.2"
           }
@@ -6235,14 +6099,12 @@
         "untildify": {
           "version": "3.0.2",
           "resolved": "https://registry.npmjs.org/untildify/-/untildify-3.0.2.tgz",
-          "integrity": "sha1-fx8wIFWz/qDz6B3HjrNnZstl4/E=",
-          "dev": true
+          "integrity": "sha1-fx8wIFWz/qDz6B3HjrNnZstl4/E="
         },
         "yeoman-environment": {
           "version": "2.0.5",
           "resolved": "https://registry.npmjs.org/yeoman-environment/-/yeoman-environment-2.0.5.tgz",
-          "integrity": "sha1-hPIrr6hAiJcf6Z6oX2VKOj3StpM=",
-          "dev": true,
+          "integrity": "sha512-6/W7/B54OPHJXob0n0+pmkwFsirC8cokuQkPSmT/D0lCcSxkKtg/BA6ZnjUBIwjuGqmw3DTrT4en++htaUju5g==",
           "requires": {
             "chalk": "2.3.0",
             "debug": "3.1.0",

--- a/generator-java/package.json
+++ b/generator-java/package.json
@@ -16,7 +16,7 @@
     "extend": "^3.0.1",
     "ibm-java-codegen-common": "3.0.0",
     "generator-ibm-cloud-enablement": "0.7.0",
-    "generator-ibm-service-enablement": "0.6.0",
+    "generator-ibm-service-enablement": "0.7.0",
     "generator-ibm-usecase-enablement": "3.0.0",
     "yeoman-assert": "^2.2.2",
     "yeoman-test": "^1.6.0",

--- a/generator-java/package.json
+++ b/generator-java/package.json
@@ -14,7 +14,7 @@
     "generator-ibm-java-liberty": "8.0.1",
     "generator-ibm-java-spring": "2.0.1",
     "extend": "^3.0.1",
-    "ibm-java-codegen-common": "3.0.0",
+    "ibm-java-codegen-common": "3.0.1",
     "generator-ibm-cloud-enablement": "0.7.0",
     "generator-ibm-service-enablement": "0.7.0",
     "generator-ibm-usecase-enablement": "3.0.0",


### PR DESCRIPTION
Update to version  0.7.0 of service-enablement to get Spring Cloudant templates using the Spring Boot cloudant starter.

Signed-off-by: Katherine Stanley <katheris@uk.ibm.com>