### PR TITLE
fix(logging): Reduce logging output

### DIFF
--- a/generator-java/generators/app/index.js
+++ b/generator-java/generators/app/index.js
@@ -54,10 +54,8 @@ module.exports = class extends Generator {
 
   initializing () {
     config = new Config(defaults)
-    logger.writeToLog(`${logId}:initializing - Config (default)`, config)
     //overwrite any default values with those specified as options
     config.overwrite(this.options)
-    logger.writeToLog(`${logId}:initializing - Config (after clone)`, config)
 
     //set values based on either defaults or passed in values
     if (config.bluemix) {


### PR DESCRIPTION
Remove repeats of config object logging to reduce log size and improve readability.

Signed-off-by: Katherine Stanley <katheris@uk.ibm.com>