### PR TITLE
fix(templates): Update Liberty pom.xml template

### DIFF
--- a/generator-java/package.json
+++ b/generator-java/package.json
@@ -11,11 +11,11 @@
   "dependencies": {
     "handlebars": "^4.0.0",
     "yeoman-generator": "^1.0.0",
-    "generator-ibm-java-liberty": "8.0.1",
+    "generator-ibm-java-liberty": "8.0.2",
     "generator-ibm-java-spring": "2.0.1",
     "extend": "^3.0.1",
     "ibm-java-codegen-common": "3.0.1",
-    "generator-ibm-cloud-enablement": "0.7.0",
+    "generator-ibm-cloud-enablement": "0.8.1",
     "generator-ibm-service-enablement": "0.7.0",
     "generator-ibm-usecase-enablement": "3.0.0",
     "yeoman-assert": "^2.2.2",


### PR DESCRIPTION
Update to version 8.0.2 of java-liberty and version 0.8.1 of cloud-enablement to get the fix for the bx dev build problem in Windows 10

Signed-off-by: Patrick Tiu <tiu@ca.ibm.com>