### PR TITLE
fix(test): Look for kube secrets in bindings.yaml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,11 +4,13 @@ jdk:
 before_install:
   - wget http://services.gradle.org/distributions/gradle-3.5-bin.zip
   - wget https://github.com/github/hub/releases/download/v2.2.9/hub-linux-386-2.2.9.tgz
+  - wget https://kubernetes-helm.storage.googleapis.com/helm-v2.7.2-linux-amd64.tar.gz
   - shasum -a 256 -c ./sha256.txt
   - unzip -qq gradle-3.5-bin.zip
   - tar -xvzf hub-linux-386-2.2.9.tgz
   - export GRADLE_HOME=$PWD/gradle-3.5
-  - export PATH=$GRADLE_HOME/bin:$PWD/hub-linux-386-2.2.9/bin/:$PATH
+  - tar -xvf helm-v2.7.2-linux-amd64.tar.gz
+  - export PATH=$GRADLE_HOME/bin:$PWD/hub-linux-386-2.2.9/bin/:$PWD/linux-amd64:$PATH
   - gradle -v
   - nvm install 6.9.1
   - cd ./generator-java

--- a/generator-java/.editorconfig
+++ b/generator-java/.editorconfig
@@ -1,0 +1,25 @@
+# EditorConfig helps developers define and maintain consistent
+# coding styles between different editors and IDEs
+# editorconfig.org
+
+root = true
+
+[*]
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+indent_style = space
+
+[*.{md}]
+indent_size = 2
+trim_trailing_whitespace = false
+
+[*.java]
+indent_size = 4
+
+[*.js]
+indent_size = 2
+
+[*.{html,rb,css,xml,sh,yaml,yml}]
+indent_size = 2

--- a/generator-java/.eslintignore
+++ b/generator-java/.eslintignore
@@ -3,3 +3,4 @@ node_modules/
 # We either rename the package.json template, or we don't lint this dir
 test/resources/*
 generators/app/templates/*
+coverage/

--- a/generator-java/.eslintrc.yml
+++ b/generator-java/.eslintrc.yml
@@ -4,9 +4,8 @@ env:
   mocha: true
 
 rules:
-  strict: 2
+  strict: 0
   no-var: 2
   no-console: 0
-  indent: ["error", 2, { "SwitchCase": 1}]
 
 extends: eslint:recommended

--- a/generator-java/lib/assert/internal/assert.core.bx.js
+++ b/generator-java/lib/assert/internal/assert.core.bx.js
@@ -141,7 +141,7 @@ class AssertBx extends Assert {
       })
       it('should create file ' + constant.LOCALDEV_FILE + ' with Object Storage credentials', function () {
         assert.fileContent(constant.LOCALDEV_FILE, '"object_storage_project": "objectStorage-project"')
-        assert.fileContent(constant.LOCALDEV_FILE, '"object_storage_user_id": "objectStorage-userId"')
+        assert.fileContent(constant.LOCALDEV_FILE, '"object_storage_userId": "objectStorage-userId"')
         assert.fileContent(constant.LOCALDEV_FILE, '"object_storage_password": "objectStorage-password"')
         assert.fileContent(constant.LOCALDEV_FILE, '"object_storage_auth_url": "objectStorage-url"')
         assert.fileContent(constant.LOCALDEV_FILE, '"object_storage_domainName": "objectStorage-domainName"')

--- a/generator-java/package-lock.json
+++ b/generator-java/package-lock.json
@@ -9,8 +9,8 @@
       "resolved": "https://registry.npmjs.org/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz",
       "integrity": "sha512-bPHp6Ji8b41szTOcaP63VlnbbO5Ny6dwAATtY6JTjh5N2OLrb5Qk/Th5cRkRQhkWCt+EJsYrNB0MiL+Gpn6e3g==",
       "requires": {
-        "call-me-maybe": "1.0.1",
-        "glob-to-regexp": "0.3.0"
+        "call-me-maybe": "^1.0.1",
+        "glob-to-regexp": "^0.3.0"
       }
     },
     "@nodelib/fs.stat": {
@@ -27,12 +27,12 @@
       }
     },
     "JSONStream": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.2.tgz",
-      "integrity": "sha1-wQI3G27Dp887hHygDCC7D85Mbeo=",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.3.tgz",
+      "integrity": "sha512-3Sp6WZZ/lXl+nTDoGpGWHEpTnnC6X5fnkolYZR6nwIfzbxxvA8utPWe1gCt7i0m9uVGsSz2IS8K8mJ7HmlduMg==",
       "requires": {
-        "jsonparse": "1.3.1",
-        "through": "2.3.8"
+        "jsonparse": "^1.2.0",
+        "through": ">=2.2.7 <3"
       }
     },
     "acorn": {
@@ -47,7 +47,7 @@
       "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
       "dev": true,
       "requires": {
-        "acorn": "3.3.0"
+        "acorn": "^3.0.4"
       },
       "dependencies": {
         "acorn": {
@@ -63,10 +63,10 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
       "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
       "requires": {
-        "co": "4.6.0",
-        "fast-deep-equal": "1.0.0",
-        "fast-json-stable-stringify": "2.0.0",
-        "json-schema-traverse": "0.3.1"
+        "co": "^4.6.0",
+        "fast-deep-equal": "^1.0.0",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.3.0"
       }
     },
     "ajv-keywords": {
@@ -80,9 +80,9 @@
       "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
       "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
       "requires": {
-        "kind-of": "3.2.2",
-        "longest": "1.0.1",
-        "repeat-string": "1.6.1"
+        "kind-of": "^3.0.2",
+        "longest": "^1.0.1",
+        "repeat-string": "^1.5.2"
       }
     },
     "amdefine": {
@@ -110,7 +110,7 @@
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
       "integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
       "requires": {
-        "sprintf-js": "1.0.3"
+        "sprintf-js": "~1.0.2"
       }
     },
     "arr-diff": {
@@ -148,7 +148,7 @@
       "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
       "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
       "requires": {
-        "array-uniq": "1.0.3"
+        "array-uniq": "^1.0.1"
       }
     },
     "array-uniq": {
@@ -202,9 +202,9 @@
       "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
     },
     "aws4": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
-      "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4="
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.7.0.tgz",
+      "integrity": "sha512-32NDda82rhwD9/JBCCkB+MRYDp0oSvlo2IL6rQWA10PQi7tDUM3eqMSltXmY+Oyl/7N3P3qNtAlv7X0d9bI28w=="
     },
     "babel-code-frame": {
       "version": "6.26.0",
@@ -212,9 +212,9 @@
       "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
       "dev": true,
       "requires": {
-        "chalk": "1.1.3",
-        "esutils": "2.0.2",
-        "js-tokens": "3.0.2"
+        "chalk": "^1.1.3",
+        "esutils": "^2.0.2",
+        "js-tokens": "^3.0.2"
       }
     },
     "balanced-match": {
@@ -227,13 +227,13 @@
       "resolved": "https://registry.npmjs.org/base/-/base-0.11.2.tgz",
       "integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
       "requires": {
-        "cache-base": "1.0.1",
-        "class-utils": "0.3.6",
-        "component-emitter": "1.2.1",
-        "define-property": "1.0.0",
-        "isobject": "3.0.1",
-        "mixin-deep": "1.3.1",
-        "pascalcase": "0.1.1"
+        "cache-base": "^1.0.1",
+        "class-utils": "^0.3.5",
+        "component-emitter": "^1.2.1",
+        "define-property": "^1.0.0",
+        "isobject": "^3.0.1",
+        "mixin-deep": "^1.2.0",
+        "pascalcase": "^0.1.1"
       },
       "dependencies": {
         "define-property": {
@@ -241,7 +241,7 @@
           "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
           "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
           "requires": {
-            "is-descriptor": "1.0.2"
+            "is-descriptor": "^1.0.0"
           }
         },
         "is-accessor-descriptor": {
@@ -249,7 +249,7 @@
           "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
           "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
           "requires": {
-            "kind-of": "6.0.2"
+            "kind-of": "^6.0.0"
           }
         },
         "is-data-descriptor": {
@@ -257,7 +257,7 @@
           "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
           "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
           "requires": {
-            "kind-of": "6.0.2"
+            "kind-of": "^6.0.0"
           }
         },
         "is-descriptor": {
@@ -265,9 +265,9 @@
           "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
           "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
           "requires": {
-            "is-accessor-descriptor": "1.0.0",
-            "is-data-descriptor": "1.0.0",
-            "kind-of": "6.0.2"
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
           }
         },
         "kind-of": {
@@ -283,7 +283,7 @@
       "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
       "optional": true,
       "requires": {
-        "tweetnacl": "0.14.5"
+        "tweetnacl": "^0.14.3"
       }
     },
     "binary": {
@@ -291,8 +291,8 @@
       "resolved": "https://registry.npmjs.org/binary/-/binary-0.3.0.tgz",
       "integrity": "sha1-n2BVO8XOjDOG87VTz/R0Yq3sqnk=",
       "requires": {
-        "buffers": "0.1.1",
-        "chainsaw": "0.1.0"
+        "buffers": "~0.1.1",
+        "chainsaw": "~0.1.0"
       }
     },
     "binaryextensions": {
@@ -305,20 +305,12 @@
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
       "integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA=="
     },
-    "boom": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/boom/-/boom-4.3.1.tgz",
-      "integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
-      "requires": {
-        "hoek": "4.2.0"
-      }
-    },
     "brace-expansion": {
       "version": "1.1.8",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
       "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
       "requires": {
-        "balanced-match": "1.0.0",
+        "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
     },
@@ -327,16 +319,16 @@
       "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
       "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
       "requires": {
-        "arr-flatten": "1.1.0",
-        "array-unique": "0.3.2",
-        "extend-shallow": "2.0.1",
-        "fill-range": "4.0.0",
-        "isobject": "3.0.1",
-        "repeat-element": "1.1.2",
-        "snapdragon": "0.8.2",
-        "snapdragon-node": "2.1.1",
-        "split-string": "3.1.0",
-        "to-regex": "3.0.2"
+        "arr-flatten": "^1.1.0",
+        "array-unique": "^0.3.2",
+        "extend-shallow": "^2.0.1",
+        "fill-range": "^4.0.0",
+        "isobject": "^3.0.1",
+        "repeat-element": "^1.1.2",
+        "snapdragon": "^0.8.1",
+        "snapdragon-node": "^2.0.1",
+        "split-string": "^3.0.2",
+        "to-regex": "^3.0.1"
       },
       "dependencies": {
         "extend-shallow": {
@@ -344,7 +336,7 @@
           "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "requires": {
-            "is-extendable": "0.1.1"
+            "is-extendable": "^0.1.0"
           }
         }
       }
@@ -370,15 +362,15 @@
       "resolved": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
       "integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
       "requires": {
-        "collection-visit": "1.0.0",
-        "component-emitter": "1.2.1",
-        "get-value": "2.0.6",
-        "has-value": "1.0.0",
-        "isobject": "3.0.1",
-        "set-value": "2.0.0",
-        "to-object-path": "0.3.0",
-        "union-value": "1.0.0",
-        "unset-value": "1.0.0"
+        "collection-visit": "^1.0.0",
+        "component-emitter": "^1.2.1",
+        "get-value": "^2.0.6",
+        "has-value": "^1.0.0",
+        "isobject": "^3.0.1",
+        "set-value": "^2.0.0",
+        "to-object-path": "^0.3.0",
+        "union-value": "^1.0.0",
+        "unset-value": "^1.0.0"
       }
     },
     "call-me-maybe": {
@@ -392,7 +384,7 @@
       "integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
       "dev": true,
       "requires": {
-        "callsites": "0.2.0"
+        "callsites": "^0.2.0"
       }
     },
     "callsites": {
@@ -412,8 +404,8 @@
       "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
       "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
       "requires": {
-        "camelcase": "2.1.1",
-        "map-obj": "1.0.1"
+        "camelcase": "^2.0.0",
+        "map-obj": "^1.0.0"
       },
       "dependencies": {
         "camelcase": {
@@ -439,8 +431,8 @@
       "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
       "optional": true,
       "requires": {
-        "align-text": "0.1.4",
-        "lazy-cache": "1.0.4"
+        "align-text": "^0.1.3",
+        "lazy-cache": "^1.0.3"
       }
     },
     "chainsaw": {
@@ -448,7 +440,7 @@
       "resolved": "https://registry.npmjs.org/chainsaw/-/chainsaw-0.1.0.tgz",
       "integrity": "sha1-XqtQsor+WAdNDVgpE4iCi15fvJg=",
       "requires": {
-        "traverse": "0.3.9"
+        "traverse": ">=0.3.0 <0.4"
       }
     },
     "chalk": {
@@ -456,11 +448,11 @@
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
       "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
       "requires": {
-        "ansi-styles": "2.2.1",
-        "escape-string-regexp": "1.0.5",
-        "has-ansi": "2.0.0",
-        "strip-ansi": "3.0.1",
-        "supports-color": "2.0.0"
+        "ansi-styles": "^2.2.1",
+        "escape-string-regexp": "^1.0.2",
+        "has-ansi": "^2.0.0",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^2.0.0"
       }
     },
     "chardet": {
@@ -479,7 +471,7 @@
       "resolved": "https://registry.npmjs.org/class-extend/-/class-extend-0.1.2.tgz",
       "integrity": "sha1-gFeoKwD1P4Kl1ixQ74z/3sb6vDQ=",
       "requires": {
-        "object-assign": "2.1.1"
+        "object-assign": "^2.0.0"
       }
     },
     "class-utils": {
@@ -487,10 +479,10 @@
       "resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
       "integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
       "requires": {
-        "arr-union": "3.1.0",
-        "define-property": "0.2.5",
-        "isobject": "3.0.1",
-        "static-extend": "0.1.2"
+        "arr-union": "^3.1.0",
+        "define-property": "^0.2.5",
+        "isobject": "^3.0.0",
+        "static-extend": "^0.1.1"
       },
       "dependencies": {
         "define-property": {
@@ -498,7 +490,7 @@
           "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "requires": {
-            "is-descriptor": "0.1.6"
+            "is-descriptor": "^0.1.0"
           }
         }
       }
@@ -508,7 +500,7 @@
       "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
       "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
       "requires": {
-        "restore-cursor": "1.0.1"
+        "restore-cursor": "^1.0.1"
       }
     },
     "cli-table": {
@@ -530,8 +522,8 @@
       "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
       "optional": true,
       "requires": {
-        "center-align": "0.1.3",
-        "right-align": "0.1.3",
+        "center-align": "^0.1.1",
+        "right-align": "^0.1.1",
         "wordwrap": "0.0.2"
       },
       "dependencies": {
@@ -563,9 +555,9 @@
       "resolved": "https://registry.npmjs.org/cloneable-readable/-/cloneable-readable-1.0.0.tgz",
       "integrity": "sha1-pikNQT8hemEjL5XkWP84QYz7ARc=",
       "requires": {
-        "inherits": "2.0.3",
-        "process-nextick-args": "1.0.7",
-        "through2": "2.0.3"
+        "inherits": "^2.0.1",
+        "process-nextick-args": "^1.0.6",
+        "through2": "^2.0.1"
       }
     },
     "co": {
@@ -583,8 +575,8 @@
       "resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
       "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
       "requires": {
-        "map-visit": "1.0.0",
-        "object-visit": "1.0.1"
+        "map-visit": "^1.0.0",
+        "object-visit": "^1.0.0"
       }
     },
     "color-convert": {
@@ -592,7 +584,7 @@
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
       "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
       "requires": {
-        "color-name": "1.1.3"
+        "color-name": "^1.1.1"
       }
     },
     "color-name": {
@@ -606,29 +598,23 @@
       "integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs="
     },
     "combined-stream": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
-      "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
+      "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
       "requires": {
-        "delayed-stream": "1.0.0"
+        "delayed-stream": "~1.0.0"
       }
-    },
-    "commander": {
-      "version": "2.12.2",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.12.2.tgz",
-      "integrity": "sha512-BFnaq5ZOGcDN7FlrtBT4xxkgIToalIIxwjxLWVJ8bGTpe1LroqMiqQXdA7ygc7CRvaYS+9zfPGFnJqFSayx+AA==",
-      "dev": true
     },
     "common-codegen-tests": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/common-codegen-tests/-/common-codegen-tests-2.2.3.tgz",
       "integrity": "sha1-niMDzptNbHTSe79L5Fqqqg/FhKo=",
       "requires": {
-        "js-yaml": "3.11.0",
-        "semver": "5.4.1",
-        "standard-version": "4.3.0",
-        "yeoman-assert": "2.2.3",
-        "yeoman-test": "1.7.2"
+        "js-yaml": "^3.8.2",
+        "semver": "^5.4.1",
+        "standard-version": "^4.0.0",
+        "yeoman-assert": "^2.2.2",
+        "yeoman-test": "^1.6.0"
       }
     },
     "commondir": {
@@ -641,8 +627,8 @@
       "resolved": "https://registry.npmjs.org/compare-func/-/compare-func-1.3.2.tgz",
       "integrity": "sha1-md0LpFfh+bxyKxLAjsM+6rMfpkg=",
       "requires": {
-        "array-ify": "1.0.0",
-        "dot-prop": "3.0.0"
+        "array-ify": "^1.0.0",
+        "dot-prop": "^3.0.0"
       }
     },
     "component-emitter": {
@@ -660,89 +646,86 @@
       "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
       "integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=",
       "requires": {
-        "inherits": "2.0.3",
-        "readable-stream": "2.3.3",
-        "typedarray": "0.0.6"
+        "inherits": "^2.0.3",
+        "readable-stream": "^2.2.2",
+        "typedarray": "^0.0.6"
       }
     },
     "conventional-changelog": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/conventional-changelog/-/conventional-changelog-1.1.7.tgz",
-      "integrity": "sha1-kVGmKx2O2y2CcR2r9bfPcQQfgrE=",
+      "version": "1.1.24",
+      "resolved": "https://registry.npmjs.org/conventional-changelog/-/conventional-changelog-1.1.24.tgz",
+      "integrity": "sha512-2WcSUst4Y3Z4hHvoMTWXMJr/DmgVdLiMOVY1Kak2LfFz+GIz2KDp5naqbFesYbfXPmaZ5p491dO0FWZIJoJw1Q==",
       "requires": {
-        "conventional-changelog-angular": "1.6.0",
-        "conventional-changelog-atom": "0.1.2",
-        "conventional-changelog-codemirror": "0.2.1",
-        "conventional-changelog-core": "1.9.5",
-        "conventional-changelog-ember": "0.2.10",
-        "conventional-changelog-eslint": "0.2.1",
-        "conventional-changelog-express": "0.2.1",
-        "conventional-changelog-jquery": "0.1.0",
-        "conventional-changelog-jscs": "0.1.0",
-        "conventional-changelog-jshint": "0.2.1"
+        "conventional-changelog-angular": "^1.6.6",
+        "conventional-changelog-atom": "^0.2.8",
+        "conventional-changelog-codemirror": "^0.3.8",
+        "conventional-changelog-core": "^2.0.11",
+        "conventional-changelog-ember": "^0.3.12",
+        "conventional-changelog-eslint": "^1.0.9",
+        "conventional-changelog-express": "^0.3.6",
+        "conventional-changelog-jquery": "^0.1.0",
+        "conventional-changelog-jscs": "^0.1.0",
+        "conventional-changelog-jshint": "^0.3.8",
+        "conventional-changelog-preset-loader": "^1.1.8"
       }
     },
     "conventional-changelog-angular": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-1.6.0.tgz",
-      "integrity": "sha1-CiagcfLJ/PzyuGugz79uYwG3W/o=",
+      "version": "1.6.6",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-1.6.6.tgz",
+      "integrity": "sha512-suQnFSqCxRwyBxY68pYTsFkG0taIdinHLNEAX5ivtw8bCRnIgnpvcHmlR/yjUyZIrNPYAoXlY1WiEKWgSE4BNg==",
       "requires": {
-        "compare-func": "1.3.2",
-        "q": "1.5.1"
+        "compare-func": "^1.3.1",
+        "q": "^1.5.1"
       }
     },
     "conventional-changelog-atom": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-atom/-/conventional-changelog-atom-0.1.2.tgz",
-      "integrity": "sha1-Ella1SZ6aTfDTPkAKBscZRmKTGM=",
+      "version": "0.2.8",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-atom/-/conventional-changelog-atom-0.2.8.tgz",
+      "integrity": "sha512-8pPZqhMbrnltNBizjoDCb/Sz85KyUXNDQxuAEYAU5V/eHn0okMBVjqc8aHWYpHrytyZWvMGbayOlDv7i8kEf6g==",
       "requires": {
-        "q": "1.5.1"
+        "q": "^1.5.1"
       }
     },
     "conventional-changelog-codemirror": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-codemirror/-/conventional-changelog-codemirror-0.2.1.tgz",
-      "integrity": "sha1-KZpPcUe681DmyBWPxUlUopHFzAk=",
+      "version": "0.3.8",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-codemirror/-/conventional-changelog-codemirror-0.3.8.tgz",
+      "integrity": "sha512-3HFZKtBXTaUCHvz7ai6nk2+psRIkldDoNzCsom0egDtVmPsvvHZkzjynhdQyULfacRSsBTaiQ0ol6nBOL4dDiQ==",
       "requires": {
-        "q": "1.5.1"
+        "q": "^1.5.1"
       }
     },
     "conventional-changelog-core": {
-      "version": "1.9.5",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-core/-/conventional-changelog-core-1.9.5.tgz",
-      "integrity": "sha1-XbdWba18DLddr0f7spdve/mSjB0=",
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-core/-/conventional-changelog-core-2.0.11.tgz",
+      "integrity": "sha512-HvTE6RlqeEZ/NFPtQeFLsIDOLrGP3bXYr7lFLMhCVsbduF1MXIe8OODkwMFyo1i9ku9NWBwVnVn0jDmIFXjDRg==",
       "requires": {
-        "conventional-changelog-writer": "2.0.3",
-        "conventional-commits-parser": "2.1.0",
-        "dateformat": "1.0.12",
-        "get-pkg-repo": "1.4.0",
-        "git-raw-commits": "1.3.0",
-        "git-remote-origin-url": "2.0.0",
-        "git-semver-tags": "1.2.3",
-        "lodash": "4.17.4",
-        "normalize-package-data": "2.4.0",
-        "q": "1.5.1",
-        "read-pkg": "1.1.0",
-        "read-pkg-up": "1.0.1",
-        "through2": "2.0.3"
+        "conventional-changelog-writer": "^3.0.9",
+        "conventional-commits-parser": "^2.1.7",
+        "dateformat": "^3.0.0",
+        "get-pkg-repo": "^1.0.0",
+        "git-raw-commits": "^1.3.6",
+        "git-remote-origin-url": "^2.0.0",
+        "git-semver-tags": "^1.3.6",
+        "lodash": "^4.2.1",
+        "normalize-package-data": "^2.3.5",
+        "q": "^1.5.1",
+        "read-pkg": "^1.1.0",
+        "read-pkg-up": "^1.0.1",
+        "through2": "^2.0.0"
       },
       "dependencies": {
         "dateformat": {
-          "version": "1.0.12",
-          "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.12.tgz",
-          "integrity": "sha1-nxJLZ1lMk3/3BpMuSmQsyo27/uk=",
-          "requires": {
-            "get-stdin": "4.0.1",
-            "meow": "3.7.0"
-          }
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-3.0.3.tgz",
+          "integrity": "sha512-jyCETtSl3VMZMWeRo7iY1FL19ges1t55hMo5yaam4Jrsm5EPL89UQkoQRyiI+Yf4k8r2ZpdngkV8hr1lIdjb3Q=="
         },
         "find-up": {
           "version": "1.1.2",
           "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
           "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
           "requires": {
-            "path-exists": "2.1.0",
-            "pinkie-promise": "2.0.1"
+            "path-exists": "^2.0.0",
+            "pinkie-promise": "^2.0.0"
           }
         },
         "load-json-file": {
@@ -750,11 +733,11 @@
           "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
           "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
           "requires": {
-            "graceful-fs": "4.1.11",
-            "parse-json": "2.2.0",
-            "pify": "2.3.0",
-            "pinkie-promise": "2.0.1",
-            "strip-bom": "2.0.0"
+            "graceful-fs": "^4.1.2",
+            "parse-json": "^2.2.0",
+            "pify": "^2.0.0",
+            "pinkie-promise": "^2.0.0",
+            "strip-bom": "^2.0.0"
           }
         },
         "path-exists": {
@@ -762,7 +745,7 @@
           "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
           "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
           "requires": {
-            "pinkie-promise": "2.0.1"
+            "pinkie-promise": "^2.0.0"
           }
         },
         "path-type": {
@@ -770,9 +753,9 @@
           "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
           "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
           "requires": {
-            "graceful-fs": "4.1.11",
-            "pify": "2.3.0",
-            "pinkie-promise": "2.0.1"
+            "graceful-fs": "^4.1.2",
+            "pify": "^2.0.0",
+            "pinkie-promise": "^2.0.0"
           }
         },
         "read-pkg": {
@@ -780,9 +763,9 @@
           "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
           "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
           "requires": {
-            "load-json-file": "1.1.0",
-            "normalize-package-data": "2.4.0",
-            "path-type": "1.1.0"
+            "load-json-file": "^1.0.0",
+            "normalize-package-data": "^2.3.2",
+            "path-type": "^1.0.0"
           }
         },
         "read-pkg-up": {
@@ -790,8 +773,8 @@
           "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
           "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
           "requires": {
-            "find-up": "1.1.2",
-            "read-pkg": "1.1.0"
+            "find-up": "^1.0.0",
+            "read-pkg": "^1.0.0"
           }
         },
         "strip-bom": {
@@ -799,33 +782,33 @@
           "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
           "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
           "requires": {
-            "is-utf8": "0.2.1"
+            "is-utf8": "^0.2.0"
           }
         }
       }
     },
     "conventional-changelog-ember": {
-      "version": "0.2.10",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-ember/-/conventional-changelog-ember-0.2.10.tgz",
-      "integrity": "sha512-LBBBZO6Q7ib4HhSdyCNVR25OtaXl710UJg1aSHCLmR8AjuXKs3BO8tnbY1MH+D1C+z5IFoEDkpjOddefNTyhCQ==",
+      "version": "0.3.12",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-ember/-/conventional-changelog-ember-0.3.12.tgz",
+      "integrity": "sha512-mmJzA7uzbrOqeF89dMMi6z17O07ORTXlTMArnLG9ZTX4oLaKNolUlxFUFlFm9JUoVWajVpaHQWjxH1EOQ+ARoQ==",
       "requires": {
-        "q": "1.5.1"
+        "q": "^1.5.1"
       }
     },
     "conventional-changelog-eslint": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-eslint/-/conventional-changelog-eslint-0.2.1.tgz",
-      "integrity": "sha1-LCoRvrIW+AZJunKDQYApO2h8BmI=",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-eslint/-/conventional-changelog-eslint-1.0.9.tgz",
+      "integrity": "sha512-h87nfVh2fdk9fJIvz26wCBsbDC/KxqCc5wSlNMZbXcARtbgNbNDIF7Y7ctokFdnxkzVdaHsbINkh548T9eBA7Q==",
       "requires": {
-        "q": "1.5.1"
+        "q": "^1.5.1"
       }
     },
     "conventional-changelog-express": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-express/-/conventional-changelog-express-0.2.1.tgz",
-      "integrity": "sha1-g42eHmyQmXA7FQucGaoteBdCvWw=",
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-express/-/conventional-changelog-express-0.3.6.tgz",
+      "integrity": "sha512-3iWVtBJZ9RnRnZveNDzOD8QRn6g6vUif0qVTWWyi5nUIAbuN1FfPVyKdAlJJfp5Im+dE8Kiy/d2SpaX/0X678Q==",
       "requires": {
-        "q": "1.5.1"
+        "q": "^1.5.1"
       }
     },
     "conventional-changelog-jquery": {
@@ -833,7 +816,7 @@
       "resolved": "https://registry.npmjs.org/conventional-changelog-jquery/-/conventional-changelog-jquery-0.1.0.tgz",
       "integrity": "sha1-Agg5cWLjhGmG5xJztsecW1+A9RA=",
       "requires": {
-        "q": "1.5.1"
+        "q": "^1.4.1"
       }
     },
     "conventional-changelog-jscs": {
@@ -841,81 +824,323 @@
       "resolved": "https://registry.npmjs.org/conventional-changelog-jscs/-/conventional-changelog-jscs-0.1.0.tgz",
       "integrity": "sha1-BHnrRDzH1yxYvwvPDvHURKkvDlw=",
       "requires": {
-        "q": "1.5.1"
+        "q": "^1.4.1"
       }
     },
     "conventional-changelog-jshint": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-jshint/-/conventional-changelog-jshint-0.2.1.tgz",
-      "integrity": "sha1-hhObs6yZiZ8rF36WF+CbN9mbzzo=",
+      "version": "0.3.8",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-jshint/-/conventional-changelog-jshint-0.3.8.tgz",
+      "integrity": "sha512-hn9QU4ZI/5V50wKPJNPGT4gEWgiBFpV6adieILW4MaUFynuDYOvQ71EMSj3EznJyKi/KzuXpc9dGmX8njZMjig==",
       "requires": {
-        "compare-func": "1.3.2",
-        "q": "1.5.1"
+        "compare-func": "^1.3.1",
+        "q": "^1.5.1"
       }
     },
+    "conventional-changelog-preset-loader": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-preset-loader/-/conventional-changelog-preset-loader-1.1.8.tgz",
+      "integrity": "sha512-MkksM4G4YdrMlT2MbTsV2F6LXu/hZR0Tc/yenRrDIKRwBl/SP7ER4ZDlglqJsCzLJi4UonBc52Bkm5hzrOVCcw=="
+    },
     "conventional-changelog-writer": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-writer/-/conventional-changelog-writer-2.0.3.tgz",
-      "integrity": "sha512-2E1h7UXL0fhRO5h0CxDZ5EBc5sfBZEQePvuZ+gPvApiRrICUyNDy/NQIP+2TBd4wKZQf2Zm7TxbzXHG5HkPIbA==",
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-writer/-/conventional-changelog-writer-3.0.9.tgz",
+      "integrity": "sha512-n9KbsxlJxRQsUnK6wIBRnARacvNnN4C/nxnxCkH+B/R1JS2Fa+DiP1dU4I59mEDEjgnFaN2+9wr1P1s7GYB5/Q==",
       "requires": {
-        "compare-func": "1.3.2",
-        "conventional-commits-filter": "1.1.1",
-        "dateformat": "1.0.12",
-        "handlebars": "4.0.11",
-        "json-stringify-safe": "5.0.1",
-        "lodash": "4.17.4",
-        "meow": "3.7.0",
-        "semver": "5.4.1",
-        "split": "1.0.1",
-        "through2": "2.0.3"
+        "compare-func": "^1.3.1",
+        "conventional-commits-filter": "^1.1.6",
+        "dateformat": "^3.0.0",
+        "handlebars": "^4.0.2",
+        "json-stringify-safe": "^5.0.1",
+        "lodash": "^4.2.1",
+        "meow": "^4.0.0",
+        "semver": "^5.5.0",
+        "split": "^1.0.0",
+        "through2": "^2.0.0"
       },
       "dependencies": {
-        "dateformat": {
-          "version": "1.0.12",
-          "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.12.tgz",
-          "integrity": "sha1-nxJLZ1lMk3/3BpMuSmQsyo27/uk=",
+        "camelcase": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+          "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
+        },
+        "camelcase-keys": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-4.2.0.tgz",
+          "integrity": "sha1-oqpfsa9oh1glnDLBQUJteJI7m3c=",
           "requires": {
-            "get-stdin": "4.0.1",
-            "meow": "3.7.0"
+            "camelcase": "^4.1.0",
+            "map-obj": "^2.0.0",
+            "quick-lru": "^1.0.0"
           }
+        },
+        "dateformat": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-3.0.3.tgz",
+          "integrity": "sha512-jyCETtSl3VMZMWeRo7iY1FL19ges1t55hMo5yaam4Jrsm5EPL89UQkoQRyiI+Yf4k8r2ZpdngkV8hr1lIdjb3Q=="
+        },
+        "indent-string": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-3.2.0.tgz",
+          "integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok="
+        },
+        "load-json-file": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
+          "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "parse-json": "^4.0.0",
+            "pify": "^3.0.0",
+            "strip-bom": "^3.0.0"
+          }
+        },
+        "map-obj": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-2.0.0.tgz",
+          "integrity": "sha1-plzSkIepJZi4eRJXpSPgISIqwfk="
+        },
+        "meow": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/meow/-/meow-4.0.1.tgz",
+          "integrity": "sha512-xcSBHD5Z86zaOc+781KrupuHAzeGXSLtiAOmBsiLDiPSaYSB6hdew2ng9EBAnZ62jagG9MHAOdxpDi/lWBFJ/A==",
+          "requires": {
+            "camelcase-keys": "^4.0.0",
+            "decamelize-keys": "^1.0.0",
+            "loud-rejection": "^1.0.0",
+            "minimist": "^1.1.3",
+            "minimist-options": "^3.0.1",
+            "normalize-package-data": "^2.3.4",
+            "read-pkg-up": "^3.0.0",
+            "redent": "^2.0.0",
+            "trim-newlines": "^2.0.0"
+          }
+        },
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+        },
+        "parse-json": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+          "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
+          "requires": {
+            "error-ex": "^1.3.1",
+            "json-parse-better-errors": "^1.0.1"
+          }
+        },
+        "path-type": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
+          "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
+          "requires": {
+            "pify": "^3.0.0"
+          }
+        },
+        "pify": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
+        },
+        "read-pkg": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
+          "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
+          "requires": {
+            "load-json-file": "^4.0.0",
+            "normalize-package-data": "^2.3.2",
+            "path-type": "^3.0.0"
+          }
+        },
+        "read-pkg-up": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-3.0.0.tgz",
+          "integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
+          "requires": {
+            "find-up": "^2.0.0",
+            "read-pkg": "^3.0.0"
+          }
+        },
+        "redent": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/redent/-/redent-2.0.0.tgz",
+          "integrity": "sha1-wbIAe0LVfrE4kHmzyDM2OdXhzKo=",
+          "requires": {
+            "indent-string": "^3.0.0",
+            "strip-indent": "^2.0.0"
+          }
+        },
+        "semver": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
+          "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA=="
+        },
+        "strip-indent": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-2.0.0.tgz",
+          "integrity": "sha1-XvjbKV0B5u1sv3qrlpmNeCJSe2g="
+        },
+        "trim-newlines": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-2.0.0.tgz",
+          "integrity": "sha1-tAPQuRvlDDMd/EuC7s6yLD3hbSA="
         }
       }
     },
     "conventional-commits-filter": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/conventional-commits-filter/-/conventional-commits-filter-1.1.1.tgz",
-      "integrity": "sha512-bQyatySNKHhcaeKVr9vFxYWA1W1Tdz6ybVMYDmv4/FhOXY1+fchiW07TzRbIQZhVa4cvBwrEaEUQBbCncFSdJQ==",
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/conventional-commits-filter/-/conventional-commits-filter-1.1.6.tgz",
+      "integrity": "sha512-KcDgtCRKJCQhyk6VLT7zR+ZOyCnerfemE/CsR3iQpzRRFbLEs0Y6rwk3mpDvtOh04X223z+1xyJ582Stfct/0Q==",
       "requires": {
-        "is-subset": "0.1.1",
-        "modify-values": "1.0.0"
+        "is-subset": "^0.1.1",
+        "modify-values": "^1.0.0"
       }
     },
     "conventional-commits-parser": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-2.1.0.tgz",
-      "integrity": "sha512-8MD05yN0Zb6aRsZnFX1ET+8rHWfWJk+my7ANCJZBU2mhz7TSB1fk2vZhkrwVy/PCllcTYAP/1T1NiWQ7Z01mKw==",
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-2.1.7.tgz",
+      "integrity": "sha512-BoMaddIEJ6B4QVMSDu9IkVImlGOSGA1I2BQyOZHeLQ6qVOJLcLKn97+fL6dGbzWEiqDzfH4OkcveULmeq2MHFQ==",
       "requires": {
-        "JSONStream": "1.3.2",
-        "is-text-path": "1.0.1",
-        "lodash": "4.17.4",
-        "meow": "3.7.0",
-        "split2": "2.2.0",
-        "through2": "2.0.3",
-        "trim-off-newlines": "1.0.1"
+        "JSONStream": "^1.0.4",
+        "is-text-path": "^1.0.0",
+        "lodash": "^4.2.1",
+        "meow": "^4.0.0",
+        "split2": "^2.0.0",
+        "through2": "^2.0.0",
+        "trim-off-newlines": "^1.0.0"
+      },
+      "dependencies": {
+        "camelcase": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+          "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
+        },
+        "camelcase-keys": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-4.2.0.tgz",
+          "integrity": "sha1-oqpfsa9oh1glnDLBQUJteJI7m3c=",
+          "requires": {
+            "camelcase": "^4.1.0",
+            "map-obj": "^2.0.0",
+            "quick-lru": "^1.0.0"
+          }
+        },
+        "indent-string": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-3.2.0.tgz",
+          "integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok="
+        },
+        "load-json-file": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
+          "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "parse-json": "^4.0.0",
+            "pify": "^3.0.0",
+            "strip-bom": "^3.0.0"
+          }
+        },
+        "map-obj": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-2.0.0.tgz",
+          "integrity": "sha1-plzSkIepJZi4eRJXpSPgISIqwfk="
+        },
+        "meow": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/meow/-/meow-4.0.1.tgz",
+          "integrity": "sha512-xcSBHD5Z86zaOc+781KrupuHAzeGXSLtiAOmBsiLDiPSaYSB6hdew2ng9EBAnZ62jagG9MHAOdxpDi/lWBFJ/A==",
+          "requires": {
+            "camelcase-keys": "^4.0.0",
+            "decamelize-keys": "^1.0.0",
+            "loud-rejection": "^1.0.0",
+            "minimist": "^1.1.3",
+            "minimist-options": "^3.0.1",
+            "normalize-package-data": "^2.3.4",
+            "read-pkg-up": "^3.0.0",
+            "redent": "^2.0.0",
+            "trim-newlines": "^2.0.0"
+          }
+        },
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+        },
+        "parse-json": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+          "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
+          "requires": {
+            "error-ex": "^1.3.1",
+            "json-parse-better-errors": "^1.0.1"
+          }
+        },
+        "path-type": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
+          "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
+          "requires": {
+            "pify": "^3.0.0"
+          }
+        },
+        "pify": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
+        },
+        "read-pkg": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
+          "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
+          "requires": {
+            "load-json-file": "^4.0.0",
+            "normalize-package-data": "^2.3.2",
+            "path-type": "^3.0.0"
+          }
+        },
+        "read-pkg-up": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-3.0.0.tgz",
+          "integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
+          "requires": {
+            "find-up": "^2.0.0",
+            "read-pkg": "^3.0.0"
+          }
+        },
+        "redent": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/redent/-/redent-2.0.0.tgz",
+          "integrity": "sha1-wbIAe0LVfrE4kHmzyDM2OdXhzKo=",
+          "requires": {
+            "indent-string": "^3.0.0",
+            "strip-indent": "^2.0.0"
+          }
+        },
+        "strip-indent": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-2.0.0.tgz",
+          "integrity": "sha1-XvjbKV0B5u1sv3qrlpmNeCJSe2g="
+        },
+        "trim-newlines": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-2.0.0.tgz",
+          "integrity": "sha1-tAPQuRvlDDMd/EuC7s6yLD3hbSA="
+        }
       }
     },
     "conventional-recommended-bump": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/conventional-recommended-bump/-/conventional-recommended-bump-1.1.0.tgz",
-      "integrity": "sha512-WK0HnYnXd9e8J1YezUlfle+Pz7HB1RYvIH6gPLAXoroQTzDSfNfGM1tHHmdrJw0/4BMr+zw0U9V1WzFEfQwE3w==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/conventional-recommended-bump/-/conventional-recommended-bump-1.2.1.tgz",
+      "integrity": "sha512-oJjG6DkRgtnr/t/VrPdzmf4XZv8c4xKVJrVT4zrSHd92KEL+EYxSbYoKq8lQ7U5yLMw7130wrcQTLRjM/T+d4w==",
       "requires": {
-        "concat-stream": "1.6.0",
-        "conventional-commits-filter": "1.1.1",
-        "conventional-commits-parser": "2.1.0",
-        "git-raw-commits": "1.3.0",
-        "git-semver-tags": "1.2.3",
-        "meow": "3.7.0",
-        "object-assign": "4.1.1"
+        "concat-stream": "^1.4.10",
+        "conventional-commits-filter": "^1.1.1",
+        "conventional-commits-parser": "^2.1.1",
+        "git-raw-commits": "^1.3.0",
+        "git-semver-tags": "^1.3.0",
+        "meow": "^3.3.0",
+        "object-assign": "^4.0.1"
       },
       "dependencies": {
         "object-assign": {
@@ -936,175 +1161,22 @@
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
     "coveralls": {
-      "version": "2.13.3",
-      "resolved": "https://registry.npmjs.org/coveralls/-/coveralls-2.13.3.tgz",
-      "integrity": "sha512-iiAmn+l1XqRwNLXhW8Rs5qHZRFMYp9ZIPjEOVRpC/c4so6Y/f4/lFi0FfR5B9cCqgyhkJ5cZmbvcVRfP8MHchw==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/coveralls/-/coveralls-3.0.1.tgz",
+      "integrity": "sha512-FAzXwiDOYLGDWH+zgoIA+8GbWv50hlx+kpEJyvzLKOdnIBv9uWoVl4DhqGgyUHpiRjAlF8KYZSipWXYtllWH6Q==",
       "dev": true,
       "requires": {
-        "js-yaml": "3.6.1",
-        "lcov-parse": "0.0.10",
-        "log-driver": "1.2.5",
-        "minimist": "1.2.0",
-        "request": "2.79.0"
+        "js-yaml": "^3.6.1",
+        "lcov-parse": "^0.0.10",
+        "log-driver": "^1.2.5",
+        "minimist": "^1.2.0",
+        "request": "^2.79.0"
       },
       "dependencies": {
-        "assert-plus": {
-          "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
-          "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ=",
-          "dev": true
-        },
-        "aws-sign2": {
-          "version": "0.6.0",
-          "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
-          "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8=",
-          "dev": true
-        },
-        "boom": {
-          "version": "2.10.1",
-          "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
-          "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
-          "dev": true,
-          "requires": {
-            "hoek": "2.16.3"
-          }
-        },
-        "caseless": {
-          "version": "0.11.0",
-          "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
-          "integrity": "sha1-cVuW6phBWTzDMGeSP17GDr2k99c=",
-          "dev": true
-        },
-        "cryptiles": {
-          "version": "2.0.5",
-          "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
-          "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
-          "dev": true,
-          "requires": {
-            "boom": "2.10.1"
-          }
-        },
-        "esprima": {
-          "version": "2.7.3",
-          "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
-          "integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE=",
-          "dev": true
-        },
-        "form-data": {
-          "version": "2.1.4",
-          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
-          "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
-          "dev": true,
-          "requires": {
-            "asynckit": "0.4.0",
-            "combined-stream": "1.0.5",
-            "mime-types": "2.1.17"
-          }
-        },
-        "har-validator": {
-          "version": "2.0.6",
-          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
-          "integrity": "sha1-zcvAgYgmWtEZtqWnyKtw7s+10n0=",
-          "dev": true,
-          "requires": {
-            "chalk": "1.1.3",
-            "commander": "2.12.2",
-            "is-my-json-valid": "2.17.1",
-            "pinkie-promise": "2.0.1"
-          }
-        },
-        "hawk": {
-          "version": "3.1.3",
-          "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
-          "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
-          "dev": true,
-          "requires": {
-            "boom": "2.10.1",
-            "cryptiles": "2.0.5",
-            "hoek": "2.16.3",
-            "sntp": "1.0.9"
-          }
-        },
-        "hoek": {
-          "version": "2.16.3",
-          "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
-          "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
-          "dev": true
-        },
-        "http-signature": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
-          "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
-          "dev": true,
-          "requires": {
-            "assert-plus": "0.2.0",
-            "jsprim": "1.4.1",
-            "sshpk": "1.13.1"
-          }
-        },
-        "js-yaml": {
-          "version": "3.6.1",
-          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.6.1.tgz",
-          "integrity": "sha1-bl/mfYsgXOTSL60Ft3geja3MSzA=",
-          "dev": true,
-          "requires": {
-            "argparse": "1.0.9",
-            "esprima": "2.7.3"
-          }
-        },
         "minimist": {
           "version": "1.2.0",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-          "dev": true
-        },
-        "qs": {
-          "version": "6.3.2",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-6.3.2.tgz",
-          "integrity": "sha1-51vV9uJoEioqDgvaYwslUMFmUCw=",
-          "dev": true
-        },
-        "request": {
-          "version": "2.79.0",
-          "resolved": "https://registry.npmjs.org/request/-/request-2.79.0.tgz",
-          "integrity": "sha1-Tf5b9r6LjNw3/Pk+BLZVd3InEN4=",
-          "dev": true,
-          "requires": {
-            "aws-sign2": "0.6.0",
-            "aws4": "1.6.0",
-            "caseless": "0.11.0",
-            "combined-stream": "1.0.5",
-            "extend": "3.0.1",
-            "forever-agent": "0.6.1",
-            "form-data": "2.1.4",
-            "har-validator": "2.0.6",
-            "hawk": "3.1.3",
-            "http-signature": "1.1.1",
-            "is-typedarray": "1.0.0",
-            "isstream": "0.1.2",
-            "json-stringify-safe": "5.0.1",
-            "mime-types": "2.1.17",
-            "oauth-sign": "0.8.2",
-            "qs": "6.3.2",
-            "stringstream": "0.0.5",
-            "tough-cookie": "2.3.3",
-            "tunnel-agent": "0.4.3",
-            "uuid": "3.1.0"
-          }
-        },
-        "sntp": {
-          "version": "1.0.9",
-          "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
-          "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
-          "dev": true,
-          "requires": {
-            "hoek": "2.16.3"
-          }
-        },
-        "tunnel-agent": {
-          "version": "0.4.3",
-          "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
-          "integrity": "sha1-Y3PbdpCf5XDgjXNYM2Xtgop07us=",
           "dev": true
         }
       }
@@ -1114,7 +1186,7 @@
       "resolved": "https://registry.npmjs.org/create-error-class/-/create-error-class-3.0.2.tgz",
       "integrity": "sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=",
       "requires": {
-        "capture-stack-trace": "1.0.0"
+        "capture-stack-trace": "^1.0.0"
       }
     },
     "cross-spawn": {
@@ -1122,27 +1194,9 @@
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
       "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
       "requires": {
-        "lru-cache": "4.1.1",
-        "shebang-command": "1.2.0",
-        "which": "1.3.0"
-      }
-    },
-    "cryptiles": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-3.1.2.tgz",
-      "integrity": "sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=",
-      "requires": {
-        "boom": "5.2.0"
-      },
-      "dependencies": {
-        "boom": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
-          "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
-          "requires": {
-            "hoek": "4.2.0"
-          }
-        }
+        "lru-cache": "^4.0.1",
+        "shebang-command": "^1.2.0",
+        "which": "^1.2.9"
       }
     },
     "currently-unhandled": {
@@ -1150,7 +1204,7 @@
       "resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
       "integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
       "requires": {
-        "array-find-index": "1.0.2"
+        "array-find-index": "^1.0.1"
       }
     },
     "dargs": {
@@ -1163,7 +1217,7 @@
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
       "requires": {
-        "assert-plus": "1.0.0"
+        "assert-plus": "^1.0.0"
       }
     },
     "date-format": {
@@ -1189,6 +1243,15 @@
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
       "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
     },
+    "decamelize-keys": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/decamelize-keys/-/decamelize-keys-1.1.0.tgz",
+      "integrity": "sha1-0XGoeTMlKAfrPLYdwcFEXQeN8tk=",
+      "requires": {
+        "decamelize": "^1.1.0",
+        "map-obj": "^1.0.0"
+      }
+    },
     "decode-uri-component": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
@@ -1199,7 +1262,7 @@
       "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
       "integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=",
       "requires": {
-        "mimic-response": "1.0.0"
+        "mimic-response": "^1.0.0"
       }
     },
     "deep-extend": {
@@ -1218,8 +1281,8 @@
       "resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
       "integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
       "requires": {
-        "is-descriptor": "1.0.2",
-        "isobject": "3.0.1"
+        "is-descriptor": "^1.0.2",
+        "isobject": "^3.0.1"
       },
       "dependencies": {
         "is-accessor-descriptor": {
@@ -1227,7 +1290,7 @@
           "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
           "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
           "requires": {
-            "kind-of": "6.0.2"
+            "kind-of": "^6.0.0"
           }
         },
         "is-data-descriptor": {
@@ -1235,7 +1298,7 @@
           "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
           "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
           "requires": {
-            "kind-of": "6.0.2"
+            "kind-of": "^6.0.0"
           }
         },
         "is-descriptor": {
@@ -1243,9 +1306,9 @@
           "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
           "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
           "requires": {
-            "is-accessor-descriptor": "1.0.0",
-            "is-data-descriptor": "1.0.0",
-            "kind-of": "6.0.2"
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
           }
         },
         "kind-of": {
@@ -1261,13 +1324,13 @@
       "integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
       "dev": true,
       "requires": {
-        "globby": "5.0.0",
-        "is-path-cwd": "1.0.0",
-        "is-path-in-cwd": "1.0.1",
-        "object-assign": "4.1.1",
-        "pify": "2.3.0",
-        "pinkie-promise": "2.0.1",
-        "rimraf": "2.6.2"
+        "globby": "^5.0.0",
+        "is-path-cwd": "^1.0.0",
+        "is-path-in-cwd": "^1.0.0",
+        "object-assign": "^4.0.1",
+        "pify": "^2.0.0",
+        "pinkie-promise": "^2.0.0",
+        "rimraf": "^2.2.8"
       },
       "dependencies": {
         "globby": {
@@ -1276,12 +1339,12 @@
           "integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
           "dev": true,
           "requires": {
-            "array-union": "1.0.2",
-            "arrify": "1.0.1",
-            "glob": "7.1.2",
-            "object-assign": "4.1.1",
-            "pify": "2.3.0",
-            "pinkie-promise": "2.0.1"
+            "array-union": "^1.0.1",
+            "arrify": "^1.0.0",
+            "glob": "^7.0.3",
+            "object-assign": "^4.0.1",
+            "pify": "^2.0.0",
+            "pinkie-promise": "^2.0.0"
           }
         },
         "object-assign": {
@@ -1312,8 +1375,8 @@
       "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-2.0.0.tgz",
       "integrity": "sha512-37qirFDz8cA5fimp9feo43fSuRo2gHwaIn6dXL8Ber1dGwUosDrGZeCCXq57WnIqE4aQ+u3eQZzsk1yOzhdwag==",
       "requires": {
-        "arrify": "1.0.1",
-        "path-type": "3.0.0"
+        "arrify": "^1.0.1",
+        "path-type": "^3.0.0"
       },
       "dependencies": {
         "path-type": {
@@ -1321,7 +1384,7 @@
           "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
           "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
           "requires": {
-            "pify": "3.0.0"
+            "pify": "^3.0.0"
           }
         },
         "pify": {
@@ -1337,7 +1400,7 @@
       "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
       "dev": true,
       "requires": {
-        "esutils": "2.0.2"
+        "esutils": "^2.0.2"
       }
     },
     "dot-prop": {
@@ -1345,7 +1408,7 @@
       "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-3.0.0.tgz",
       "integrity": "sha1-G3CK8JSknJoOfbyteQq6U52sEXc=",
       "requires": {
-        "is-obj": "1.0.1"
+        "is-obj": "^1.0.0"
       }
     },
     "dotgitignore": {
@@ -1353,8 +1416,8 @@
       "resolved": "https://registry.npmjs.org/dotgitignore/-/dotgitignore-1.0.3.tgz",
       "integrity": "sha512-eu5XjSstm0WXQsARgo6kPjkINYZlOUW+z/KtAAIBjHa5mUpMPrxJytbPIndWz6GubBuuuH5ljtVcXKnVnH5q8w==",
       "requires": {
-        "find-up": "2.1.0",
-        "minimatch": "3.0.4"
+        "find-up": "^2.1.0",
+        "minimatch": "^3.0.4"
       }
     },
     "duplexer3": {
@@ -1368,7 +1431,7 @@
       "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
       "optional": true,
       "requires": {
-        "jsbn": "0.1.1"
+        "jsbn": "~0.1.0"
       }
     },
     "editions": {
@@ -1377,17 +1440,17 @@
       "integrity": "sha1-CQcQG92iD6w8vjNMJ8vQaI3Jmls="
     },
     "ejs": {
-      "version": "2.5.7",
-      "resolved": "https://registry.npmjs.org/ejs/-/ejs-2.5.7.tgz",
-      "integrity": "sha1-zIcsFoiArjxxiXYv1f/ACJbJUYo="
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/ejs/-/ejs-2.6.1.tgz",
+      "integrity": "sha512-0xy4A/twfrRCnkhfk8ErDi5DqdAsAqeGxht4xkCUrsvhhbQNs7E+4jV0CN7+NKIY0aHE72+XvqtBIXzD31ZbXQ=="
     },
     "error": {
       "version": "7.0.2",
       "resolved": "https://registry.npmjs.org/error/-/error-7.0.2.tgz",
       "integrity": "sha1-pfdf/02ZJhJt2sDqXcOOaJFTywI=",
       "requires": {
-        "string-template": "0.2.1",
-        "xtend": "4.0.1"
+        "string-template": "~0.2.1",
+        "xtend": "~4.0.0"
       }
     },
     "error-ex": {
@@ -1395,7 +1458,7 @@
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
       "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
       "requires": {
-        "is-arrayish": "0.2.1"
+        "is-arrayish": "^0.2.1"
       }
     },
     "escape-string-regexp": {
@@ -1409,44 +1472,44 @@
       "integrity": "sha512-bT3/1x1EbZB7phzYu7vCr1v3ONuzDtX8WjuM9c0iYxe+cq+pwcKEoQjl7zd3RpC6YOLgnSy3cTN58M2jcoPDIQ==",
       "dev": true,
       "requires": {
-        "ajv": "5.5.2",
-        "babel-code-frame": "6.26.0",
-        "chalk": "2.3.2",
-        "concat-stream": "1.6.0",
-        "cross-spawn": "5.1.0",
-        "debug": "3.1.0",
-        "doctrine": "2.1.0",
-        "eslint-scope": "3.7.1",
-        "eslint-visitor-keys": "1.0.0",
-        "espree": "3.5.4",
-        "esquery": "1.0.1",
-        "esutils": "2.0.2",
-        "file-entry-cache": "2.0.0",
-        "functional-red-black-tree": "1.0.1",
-        "glob": "7.1.2",
-        "globals": "11.4.0",
-        "ignore": "3.3.7",
-        "imurmurhash": "0.1.4",
-        "inquirer": "3.3.0",
-        "is-resolvable": "1.1.0",
-        "js-yaml": "3.11.0",
-        "json-stable-stringify-without-jsonify": "1.0.1",
-        "levn": "0.3.0",
-        "lodash": "4.17.4",
-        "minimatch": "3.0.4",
-        "mkdirp": "0.5.1",
-        "natural-compare": "1.4.0",
-        "optionator": "0.8.2",
-        "path-is-inside": "1.0.2",
-        "pluralize": "7.0.0",
-        "progress": "2.0.0",
-        "regexpp": "1.1.0",
-        "require-uncached": "1.0.3",
-        "semver": "5.4.1",
-        "strip-ansi": "4.0.0",
-        "strip-json-comments": "2.0.1",
+        "ajv": "^5.3.0",
+        "babel-code-frame": "^6.22.0",
+        "chalk": "^2.1.0",
+        "concat-stream": "^1.6.0",
+        "cross-spawn": "^5.1.0",
+        "debug": "^3.1.0",
+        "doctrine": "^2.1.0",
+        "eslint-scope": "^3.7.1",
+        "eslint-visitor-keys": "^1.0.0",
+        "espree": "^3.5.4",
+        "esquery": "^1.0.0",
+        "esutils": "^2.0.2",
+        "file-entry-cache": "^2.0.0",
+        "functional-red-black-tree": "^1.0.1",
+        "glob": "^7.1.2",
+        "globals": "^11.0.1",
+        "ignore": "^3.3.3",
+        "imurmurhash": "^0.1.4",
+        "inquirer": "^3.0.6",
+        "is-resolvable": "^1.0.0",
+        "js-yaml": "^3.9.1",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "levn": "^0.3.0",
+        "lodash": "^4.17.4",
+        "minimatch": "^3.0.2",
+        "mkdirp": "^0.5.1",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.8.2",
+        "path-is-inside": "^1.0.2",
+        "pluralize": "^7.0.0",
+        "progress": "^2.0.0",
+        "regexpp": "^1.0.1",
+        "require-uncached": "^1.0.3",
+        "semver": "^5.3.0",
+        "strip-ansi": "^4.0.0",
+        "strip-json-comments": "~2.0.1",
         "table": "4.0.2",
-        "text-table": "0.2.0"
+        "text-table": "~0.2.0"
       },
       "dependencies": {
         "ansi-escapes": {
@@ -1467,7 +1530,7 @@
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
-            "color-convert": "1.9.1"
+            "color-convert": "^1.9.0"
           }
         },
         "chalk": {
@@ -1476,9 +1539,9 @@
           "integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
           "dev": true,
           "requires": {
-            "ansi-styles": "3.2.1",
-            "escape-string-regexp": "1.0.5",
-            "supports-color": "5.3.0"
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
           }
         },
         "cli-cursor": {
@@ -1487,7 +1550,7 @@
           "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
           "dev": true,
           "requires": {
-            "restore-cursor": "2.0.0"
+            "restore-cursor": "^2.0.0"
           }
         },
         "debug": {
@@ -1505,9 +1568,9 @@
           "integrity": "sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==",
           "dev": true,
           "requires": {
-            "chardet": "0.4.2",
-            "iconv-lite": "0.4.19",
-            "tmp": "0.0.33"
+            "chardet": "^0.4.0",
+            "iconv-lite": "^0.4.17",
+            "tmp": "^0.0.33"
           }
         },
         "figures": {
@@ -1516,7 +1579,7 @@
           "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
           "dev": true,
           "requires": {
-            "escape-string-regexp": "1.0.5"
+            "escape-string-regexp": "^1.0.5"
           }
         },
         "has-flag": {
@@ -1531,20 +1594,20 @@
           "integrity": "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
           "dev": true,
           "requires": {
-            "ansi-escapes": "3.1.0",
-            "chalk": "2.3.2",
-            "cli-cursor": "2.1.0",
-            "cli-width": "2.2.0",
-            "external-editor": "2.2.0",
-            "figures": "2.0.0",
-            "lodash": "4.17.4",
+            "ansi-escapes": "^3.0.0",
+            "chalk": "^2.0.0",
+            "cli-cursor": "^2.1.0",
+            "cli-width": "^2.0.0",
+            "external-editor": "^2.0.4",
+            "figures": "^2.0.0",
+            "lodash": "^4.3.0",
             "mute-stream": "0.0.7",
-            "run-async": "2.3.0",
-            "rx-lite": "4.0.8",
-            "rx-lite-aggregates": "4.0.8",
-            "string-width": "2.1.1",
-            "strip-ansi": "4.0.0",
-            "through": "2.3.8"
+            "run-async": "^2.2.0",
+            "rx-lite": "^4.0.8",
+            "rx-lite-aggregates": "^4.0.8",
+            "string-width": "^2.1.0",
+            "strip-ansi": "^4.0.0",
+            "through": "^2.3.6"
           }
         },
         "is-fullwidth-code-point": {
@@ -1565,7 +1628,7 @@
           "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
           "dev": true,
           "requires": {
-            "mimic-fn": "1.1.0"
+            "mimic-fn": "^1.0.0"
           }
         },
         "restore-cursor": {
@@ -1574,8 +1637,8 @@
           "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
           "dev": true,
           "requires": {
-            "onetime": "2.0.1",
-            "signal-exit": "3.0.2"
+            "onetime": "^2.0.0",
+            "signal-exit": "^3.0.2"
           }
         },
         "string-width": {
@@ -1584,8 +1647,8 @@
           "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
           "dev": true,
           "requires": {
-            "is-fullwidth-code-point": "2.0.0",
-            "strip-ansi": "4.0.0"
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^4.0.0"
           }
         },
         "strip-ansi": {
@@ -1594,7 +1657,7 @@
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "3.0.0"
+            "ansi-regex": "^3.0.0"
           }
         },
         "supports-color": {
@@ -1603,7 +1666,7 @@
           "integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
           "dev": true,
           "requires": {
-            "has-flag": "3.0.0"
+            "has-flag": "^3.0.0"
           }
         },
         "tmp": {
@@ -1612,10 +1675,16 @@
           "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
           "dev": true,
           "requires": {
-            "os-tmpdir": "1.0.2"
+            "os-tmpdir": "~1.0.2"
           }
         }
       }
+    },
+    "eslint-plugin-ejs": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-ejs/-/eslint-plugin-ejs-0.0.2.tgz",
+      "integrity": "sha1-0XvpLoAQJiSR0R7766fWJmgesY0=",
+      "dev": true
     },
     "eslint-scope": {
       "version": "3.7.1",
@@ -1623,8 +1692,8 @@
       "integrity": "sha1-PWPD7f2gLgbgGkUq2IyqzHzctug=",
       "dev": true,
       "requires": {
-        "esrecurse": "4.2.1",
-        "estraverse": "4.2.0"
+        "esrecurse": "^4.1.0",
+        "estraverse": "^4.1.1"
       }
     },
     "eslint-visitor-keys": {
@@ -1639,8 +1708,8 @@
       "integrity": "sha512-yAcIQxtmMiB/jL32dzEp2enBeidsB7xWPLNiw3IIkpVds1P+h7qF9YwJq1yUNzp2OKXgAprs4F61ih66UsoD1A==",
       "dev": true,
       "requires": {
-        "acorn": "5.5.3",
-        "acorn-jsx": "3.0.1"
+        "acorn": "^5.5.0",
+        "acorn-jsx": "^3.0.0"
       }
     },
     "esprima": {
@@ -1654,7 +1723,7 @@
       "integrity": "sha512-SmiyZ5zIWH9VM+SRUReLS5Q8a7GxtRdxEBVZpm98rJM7Sb+A9DVCndXfkeFUd3byderg+EbDkfnevfCwynWaNA==",
       "dev": true,
       "requires": {
-        "estraverse": "4.2.0"
+        "estraverse": "^4.0.0"
       }
     },
     "esrecurse": {
@@ -1663,7 +1732,7 @@
       "integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
       "dev": true,
       "requires": {
-        "estraverse": "4.2.0"
+        "estraverse": "^4.1.0"
       }
     },
     "estraverse": {
@@ -1683,13 +1752,13 @@
       "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
       "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
       "requires": {
-        "cross-spawn": "5.1.0",
-        "get-stream": "3.0.0",
-        "is-stream": "1.1.0",
-        "npm-run-path": "2.0.2",
-        "p-finally": "1.0.0",
-        "signal-exit": "3.0.2",
-        "strip-eof": "1.0.0"
+        "cross-spawn": "^5.0.1",
+        "get-stream": "^3.0.0",
+        "is-stream": "^1.1.0",
+        "npm-run-path": "^2.0.0",
+        "p-finally": "^1.0.0",
+        "signal-exit": "^3.0.0",
+        "strip-eof": "^1.0.0"
       }
     },
     "exit-hook": {
@@ -1702,13 +1771,13 @@
       "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
       "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
       "requires": {
-        "debug": "2.6.9",
-        "define-property": "0.2.5",
-        "extend-shallow": "2.0.1",
-        "posix-character-classes": "0.1.1",
-        "regex-not": "1.0.2",
-        "snapdragon": "0.8.2",
-        "to-regex": "3.0.2"
+        "debug": "^2.3.3",
+        "define-property": "^0.2.5",
+        "extend-shallow": "^2.0.1",
+        "posix-character-classes": "^0.1.0",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.1"
       },
       "dependencies": {
         "define-property": {
@@ -1716,7 +1785,7 @@
           "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "requires": {
-            "is-descriptor": "0.1.6"
+            "is-descriptor": "^0.1.0"
           }
         },
         "extend-shallow": {
@@ -1724,7 +1793,7 @@
           "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "requires": {
-            "is-extendable": "0.1.1"
+            "is-extendable": "^0.1.0"
           }
         }
       }
@@ -1739,8 +1808,8 @@
       "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
       "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
       "requires": {
-        "assign-symbols": "1.0.0",
-        "is-extendable": "1.0.1"
+        "assign-symbols": "^1.0.0",
+        "is-extendable": "^1.0.1"
       },
       "dependencies": {
         "is-extendable": {
@@ -1748,7 +1817,7 @@
           "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
           "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
           "requires": {
-            "is-plain-object": "2.0.4"
+            "is-plain-object": "^2.0.4"
           }
         }
       }
@@ -1758,9 +1827,9 @@
       "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-1.1.1.tgz",
       "integrity": "sha1-Etew24UPf/fnCBuvQAVwAGDEYAs=",
       "requires": {
-        "extend": "3.0.1",
-        "spawn-sync": "1.0.15",
-        "tmp": "0.0.29"
+        "extend": "^3.0.0",
+        "spawn-sync": "^1.0.15",
+        "tmp": "^0.0.29"
       }
     },
     "extglob": {
@@ -1768,14 +1837,14 @@
       "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
       "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
       "requires": {
-        "array-unique": "0.3.2",
-        "define-property": "1.0.0",
-        "expand-brackets": "2.1.4",
-        "extend-shallow": "2.0.1",
-        "fragment-cache": "0.2.1",
-        "regex-not": "1.0.2",
-        "snapdragon": "0.8.2",
-        "to-regex": "3.0.2"
+        "array-unique": "^0.3.2",
+        "define-property": "^1.0.0",
+        "expand-brackets": "^2.1.4",
+        "extend-shallow": "^2.0.1",
+        "fragment-cache": "^0.2.1",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.1"
       },
       "dependencies": {
         "define-property": {
@@ -1783,7 +1852,7 @@
           "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
           "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
           "requires": {
-            "is-descriptor": "1.0.2"
+            "is-descriptor": "^1.0.0"
           }
         },
         "extend-shallow": {
@@ -1791,7 +1860,7 @@
           "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "requires": {
-            "is-extendable": "0.1.1"
+            "is-extendable": "^0.1.0"
           }
         },
         "is-accessor-descriptor": {
@@ -1799,7 +1868,7 @@
           "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
           "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
           "requires": {
-            "kind-of": "6.0.2"
+            "kind-of": "^6.0.0"
           }
         },
         "is-data-descriptor": {
@@ -1807,7 +1876,7 @@
           "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
           "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
           "requires": {
-            "kind-of": "6.0.2"
+            "kind-of": "^6.0.0"
           }
         },
         "is-descriptor": {
@@ -1815,9 +1884,9 @@
           "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
           "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
           "requires": {
-            "is-accessor-descriptor": "1.0.0",
-            "is-data-descriptor": "1.0.0",
-            "kind-of": "6.0.2"
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
           }
         },
         "kind-of": {
@@ -1842,12 +1911,12 @@
       "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-2.2.2.tgz",
       "integrity": "sha512-TR6zxCKftDQnUAPvkrCWdBgDq/gbqx8A3ApnBrR5rMvpp6+KMJI0Igw7fkWPgeVK0uhRXTXdvO3O+YP0CaUX2g==",
       "requires": {
-        "@mrmlnc/readdir-enhanced": "2.2.1",
-        "@nodelib/fs.stat": "1.0.2",
-        "glob-parent": "3.1.0",
-        "is-glob": "4.0.0",
-        "merge2": "1.2.2",
-        "micromatch": "3.1.10"
+        "@mrmlnc/readdir-enhanced": "^2.2.1",
+        "@nodelib/fs.stat": "^1.0.1",
+        "glob-parent": "^3.1.0",
+        "is-glob": "^4.0.0",
+        "merge2": "^1.2.1",
+        "micromatch": "^3.1.10"
       }
     },
     "fast-json-stable-stringify": {
@@ -1866,8 +1935,8 @@
       "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
       "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
       "requires": {
-        "escape-string-regexp": "1.0.5",
-        "object-assign": "4.1.1"
+        "escape-string-regexp": "^1.0.5",
+        "object-assign": "^4.1.0"
       },
       "dependencies": {
         "object-assign": {
@@ -1883,8 +1952,8 @@
       "integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
       "dev": true,
       "requires": {
-        "flat-cache": "1.3.0",
-        "object-assign": "4.1.1"
+        "flat-cache": "^1.2.1",
+        "object-assign": "^4.0.1"
       },
       "dependencies": {
         "object-assign": {
@@ -1900,10 +1969,10 @@
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
       "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
       "requires": {
-        "extend-shallow": "2.0.1",
-        "is-number": "3.0.0",
-        "repeat-string": "1.6.1",
-        "to-regex-range": "2.1.1"
+        "extend-shallow": "^2.0.1",
+        "is-number": "^3.0.0",
+        "repeat-string": "^1.6.1",
+        "to-regex-range": "^2.1.0"
       },
       "dependencies": {
         "extend-shallow": {
@@ -1911,7 +1980,7 @@
           "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "requires": {
-            "is-extendable": "0.1.1"
+            "is-extendable": "^0.1.0"
           }
         }
       }
@@ -1921,7 +1990,7 @@
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
       "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
       "requires": {
-        "locate-path": "2.0.0"
+        "locate-path": "^2.0.0"
       }
     },
     "first-chunk-stream": {
@@ -1929,7 +1998,7 @@
       "resolved": "https://registry.npmjs.org/first-chunk-stream/-/first-chunk-stream-2.0.0.tgz",
       "integrity": "sha1-G97NuOCDwGZLkZRVgVd6Q6nzHXA=",
       "requires": {
-        "readable-stream": "2.3.3"
+        "readable-stream": "^2.0.2"
       }
     },
     "flat-cache": {
@@ -1938,10 +2007,10 @@
       "integrity": "sha1-0wMLMrOBVPTjt+nHCfSQ9++XxIE=",
       "dev": true,
       "requires": {
-        "circular-json": "0.3.3",
-        "del": "2.2.2",
-        "graceful-fs": "4.1.11",
-        "write": "0.2.1"
+        "circular-json": "^0.3.1",
+        "del": "^2.0.2",
+        "graceful-fs": "^4.1.2",
+        "write": "^0.2.1"
       }
     },
     "for-in": {
@@ -1955,13 +2024,13 @@
       "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
     },
     "form-data": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.1.tgz",
-      "integrity": "sha1-b7lPvXGIUwbXPRXMSX/kzE7NRL8=",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
+      "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
       "requires": {
-        "asynckit": "0.4.0",
-        "combined-stream": "1.0.5",
-        "mime-types": "2.1.17"
+        "asynckit": "^0.4.0",
+        "combined-stream": "1.0.6",
+        "mime-types": "^2.1.12"
       }
     },
     "fragment-cache": {
@@ -1969,7 +2038,7 @@
       "resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
       "integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
       "requires": {
-        "map-cache": "0.2.2"
+        "map-cache": "^0.2.2"
       }
     },
     "fs-access": {
@@ -1977,7 +2046,7 @@
       "resolved": "https://registry.npmjs.org/fs-access/-/fs-access-1.0.1.tgz",
       "integrity": "sha1-1qh/JiJxzv6+wwxVNAf7mV2od3o=",
       "requires": {
-        "null-check": "1.0.0"
+        "null-check": "^1.0.0"
       }
     },
     "fs-extra": {
@@ -1985,8 +2054,8 @@
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-2.1.2.tgz",
       "integrity": "sha1-BGxwFjzvmq1GsOSn+kZ/si1x3jU=",
       "requires": {
-        "graceful-fs": "4.1.11",
-        "jsonfile": "2.4.0"
+        "graceful-fs": "^4.1.2",
+        "jsonfile": "^2.1.0"
       }
     },
     "fs.realpath": {
@@ -1999,10 +2068,10 @@
       "resolved": "https://registry.npmjs.org/fstream/-/fstream-0.1.31.tgz",
       "integrity": "sha1-czfwWPu7vvqMn1YaKMqwhJICyYg=",
       "requires": {
-        "graceful-fs": "3.0.11",
-        "inherits": "2.0.3",
-        "mkdirp": "0.5.1",
-        "rimraf": "2.6.2"
+        "graceful-fs": "~3.0.2",
+        "inherits": "~2.0.0",
+        "mkdirp": "0.5",
+        "rimraf": "2"
       },
       "dependencies": {
         "graceful-fs": {
@@ -2010,7 +2079,7 @@
           "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.11.tgz",
           "integrity": "sha1-dhPHeKGv6mLyXGMKCG1/Osu92Bg=",
           "requires": {
-            "natives": "1.1.3"
+            "natives": "^1.1.0"
           }
         }
       }
@@ -2021,31 +2090,285 @@
       "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
       "dev": true
     },
-    "generate-function": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
-      "integrity": "sha1-aFj+fAlpt9TpCTM3ZHrHn2DfvnQ=",
-      "dev": true
-    },
-    "generate-object-property": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
-      "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
-      "dev": true,
-      "requires": {
-        "is-property": "1.0.2"
-      }
-    },
     "generator-ibm-cloud-enablement": {
-      "version": "0.13.7",
-      "resolved": "https://registry.npmjs.org/generator-ibm-cloud-enablement/-/generator-ibm-cloud-enablement-0.13.7.tgz",
-      "integrity": "sha512-CLoKjISHoCdda8OwQTJAQxQCXKufwkwxxPthaoir6lZ66FNTE8VvY2PAJh5xjHOhNMuWQktY8x2RanH9Sw11/Q==",
+      "version": "0.14.3",
+      "resolved": "https://registry.npmjs.org/generator-ibm-cloud-enablement/-/generator-ibm-cloud-enablement-0.14.3.tgz",
+      "integrity": "sha512-kOjOM+6da3HiTnBGfzl34T1+e+T8e0WOEYsKI5s9nDkmlEZPqf/nZHJMWjFo060tfbXP64AqjkMAEUH0gD9PAw==",
       "requires": {
-        "fs-extra": "2.1.2",
-        "handlebars": "4.0.11",
-        "js-yaml": "3.11.0",
-        "lodash": "4.17.4",
-        "yeoman-generator": "1.1.1"
+        "fs-extra": "^2.0.0",
+        "handlebars": "^4.0.11",
+        "js-yaml": "^3.9.0",
+        "lodash": "^4.17.4",
+        "yeoman-generator": "^1.1.0"
+      },
+      "dependencies": {
+        "ansi-escapes": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
+          "integrity": "sha1-06ioOzGapneTZisT52HHkRQiMG4="
+        },
+        "async": {
+          "version": "2.6.1",
+          "resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
+          "integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
+          "requires": {
+            "lodash": "^4.17.10"
+          }
+        },
+        "cli-cursor": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
+          "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
+          "requires": {
+            "restore-cursor": "^1.0.1"
+          }
+        },
+        "dateformat": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-2.2.0.tgz",
+          "integrity": "sha1-QGXiATz5+5Ft39gu+1Bq1MZ2kGI="
+        },
+        "deep-extend": {
+          "version": "0.4.2",
+          "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.2.tgz",
+          "integrity": "sha1-SLaZwn4zS/ifEIkr5DL25MfTSn8="
+        },
+        "diff": {
+          "version": "2.2.3",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-2.2.3.tgz",
+          "integrity": "sha1-YOr9DSjukG5Oj/ClLBIpUhAzv5k="
+        },
+        "external-editor": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-1.1.1.tgz",
+          "integrity": "sha1-Etew24UPf/fnCBuvQAVwAGDEYAs=",
+          "requires": {
+            "extend": "^3.0.0",
+            "spawn-sync": "^1.0.15",
+            "tmp": "^0.0.29"
+          }
+        },
+        "gh-got": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/gh-got/-/gh-got-5.0.0.tgz",
+          "integrity": "sha1-7pW+NxBv2HSKlvjR20uuqJ4b+oo=",
+          "requires": {
+            "got": "^6.2.0",
+            "is-plain-obj": "^1.1.0"
+          }
+        },
+        "github-username": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/github-username/-/github-username-3.0.0.tgz",
+          "integrity": "sha1-CnciGbMTB0NCnyRW0L3T21Xc57E=",
+          "requires": {
+            "gh-got": "^5.0.0"
+          }
+        },
+        "globby": {
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
+          "integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
+          "requires": {
+            "array-union": "^1.0.1",
+            "glob": "^7.0.3",
+            "object-assign": "^4.0.1",
+            "pify": "^2.0.0",
+            "pinkie-promise": "^2.0.0"
+          }
+        },
+        "got": {
+          "version": "6.7.1",
+          "resolved": "https://registry.npmjs.org/got/-/got-6.7.1.tgz",
+          "integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
+          "requires": {
+            "create-error-class": "^3.0.0",
+            "duplexer3": "^0.1.4",
+            "get-stream": "^3.0.0",
+            "is-redirect": "^1.0.0",
+            "is-retry-allowed": "^1.0.0",
+            "is-stream": "^1.0.0",
+            "lowercase-keys": "^1.0.0",
+            "safe-buffer": "^5.0.1",
+            "timed-out": "^4.0.0",
+            "unzip-response": "^2.0.1",
+            "url-parse-lax": "^1.0.0"
+          }
+        },
+        "inquirer": {
+          "version": "1.2.3",
+          "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-1.2.3.tgz",
+          "integrity": "sha1-TexvMvN+97sLLtPx0aXD9UUHSRg=",
+          "requires": {
+            "ansi-escapes": "^1.1.0",
+            "chalk": "^1.0.0",
+            "cli-cursor": "^1.0.1",
+            "cli-width": "^2.0.0",
+            "external-editor": "^1.1.0",
+            "figures": "^1.3.5",
+            "lodash": "^4.3.0",
+            "mute-stream": "0.0.6",
+            "pinkie-promise": "^2.0.0",
+            "run-async": "^2.2.0",
+            "rx": "^4.1.0",
+            "string-width": "^1.0.1",
+            "strip-ansi": "^3.0.0",
+            "through": "^2.3.6"
+          }
+        },
+        "log-symbols": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-1.0.2.tgz",
+          "integrity": "sha1-N2/3tY6jCGoPCfrMdGF+ylAeGhg=",
+          "requires": {
+            "chalk": "^1.0.0"
+          }
+        },
+        "mem-fs-editor": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/mem-fs-editor/-/mem-fs-editor-3.0.2.tgz",
+          "integrity": "sha1-3Qpuryu4prN3QAZ6pUnrUwEFr58=",
+          "requires": {
+            "commondir": "^1.0.1",
+            "deep-extend": "^0.4.0",
+            "ejs": "^2.3.1",
+            "glob": "^7.0.3",
+            "globby": "^6.1.0",
+            "mkdirp": "^0.5.0",
+            "multimatch": "^2.0.0",
+            "rimraf": "^2.2.8",
+            "through2": "^2.0.0",
+            "vinyl": "^2.0.1"
+          }
+        },
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+        },
+        "mute-stream": {
+          "version": "0.0.6",
+          "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.6.tgz",
+          "integrity": "sha1-SJYrGeFp/R38JAs/HnMXYnu8R9s="
+        },
+        "object-assign": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+        },
+        "onetime": {
+          "version": "1.1.0",
+          "resolved": "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+          "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k="
+        },
+        "restore-cursor": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
+          "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
+          "requires": {
+            "exit-hook": "^1.0.0",
+            "onetime": "^1.0.0"
+          }
+        },
+        "tmp": {
+          "version": "0.0.29",
+          "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.29.tgz",
+          "integrity": "sha1-8lEl/w3Z2jzLDC3Tce4SiLuRKMA=",
+          "requires": {
+            "os-tmpdir": "~1.0.1"
+          }
+        },
+        "untildify": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/untildify/-/untildify-2.1.0.tgz",
+          "integrity": "sha1-F+soB5h/dpUunASF/DEdBqgmouA=",
+          "requires": {
+            "os-homedir": "^1.0.0"
+          }
+        },
+        "yeoman-environment": {
+          "version": "1.6.6",
+          "resolved": "https://registry.npmjs.org/yeoman-environment/-/yeoman-environment-1.6.6.tgz",
+          "integrity": "sha1-zYX6Z9FWBg5EDXgH1+988NLR1nE=",
+          "requires": {
+            "chalk": "^1.0.0",
+            "debug": "^2.0.0",
+            "diff": "^2.1.2",
+            "escape-string-regexp": "^1.0.2",
+            "globby": "^4.0.0",
+            "grouped-queue": "^0.3.0",
+            "inquirer": "^1.0.2",
+            "lodash": "^4.11.1",
+            "log-symbols": "^1.0.1",
+            "mem-fs": "^1.1.0",
+            "text-table": "^0.2.0",
+            "untildify": "^2.0.0"
+          },
+          "dependencies": {
+            "glob": {
+              "version": "6.0.4",
+              "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
+              "integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=",
+              "requires": {
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "2 || 3",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
+              }
+            },
+            "globby": {
+              "version": "4.1.0",
+              "resolved": "https://registry.npmjs.org/globby/-/globby-4.1.0.tgz",
+              "integrity": "sha1-CA9UVJ7BuCpsYOYx/ILhIR2+lfg=",
+              "requires": {
+                "array-union": "^1.0.1",
+                "arrify": "^1.0.0",
+                "glob": "^6.0.1",
+                "object-assign": "^4.0.1",
+                "pify": "^2.0.0",
+                "pinkie-promise": "^2.0.0"
+              }
+            }
+          }
+        },
+        "yeoman-generator": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/yeoman-generator/-/yeoman-generator-1.1.1.tgz",
+          "integrity": "sha1-QMK09s374F4ZUv3XKTPw2JJdvfU=",
+          "requires": {
+            "async": "^2.0.0",
+            "chalk": "^1.0.0",
+            "class-extend": "^0.1.0",
+            "cli-table": "^0.3.1",
+            "cross-spawn": "^5.0.1",
+            "dargs": "^5.1.0",
+            "dateformat": "^2.0.0",
+            "debug": "^2.1.0",
+            "detect-conflict": "^1.0.0",
+            "error": "^7.0.2",
+            "find-up": "^2.1.0",
+            "github-username": "^3.0.0",
+            "glob": "^7.0.3",
+            "istextorbinary": "^2.1.0",
+            "lodash": "^4.11.1",
+            "mem-fs-editor": "^3.0.0",
+            "minimist": "^1.2.0",
+            "mkdirp": "^0.5.0",
+            "path-exists": "^3.0.0",
+            "path-is-absolute": "^1.0.0",
+            "pretty-bytes": "^4.0.2",
+            "read-chunk": "^2.0.0",
+            "read-pkg-up": "^2.0.0",
+            "rimraf": "^2.2.0",
+            "run-async": "^2.0.0",
+            "shelljs": "^0.7.0",
+            "text-table": "^0.2.0",
+            "through2": "^2.0.0",
+            "user-home": "^2.0.0",
+            "yeoman-environment": "^1.1.0"
+          }
+        }
       }
     },
     "generator-ibm-java-liberty": {
@@ -2053,24 +2376,291 @@
       "resolved": "https://registry.npmjs.org/generator-ibm-java-liberty/-/generator-ibm-java-liberty-8.6.2.tgz",
       "integrity": "sha1-v/aOHl7B0ynxgoK1CJYN5GkFGms=",
       "requires": {
-        "bluebird": "3.5.1",
-        "escape-string-regexp": "1.0.5",
-        "extend": "3.0.1",
-        "handlebars": "4.0.11",
+        "bluebird": "^3.5.0",
+        "escape-string-regexp": "^1.0.5",
+        "extend": "^3.0.1",
+        "handlebars": "^4.0.0",
         "ibm-java-codegen-common": "3.0.0",
-        "request": "2.83.0",
-        "unzip2": "0.2.5",
-        "yeoman-assert": "2.2.3",
-        "yeoman-generator": "1.1.1"
+        "request": "^2.81.0",
+        "unzip2": "^0.2.5",
+        "yeoman-assert": "^2.2.2",
+        "yeoman-generator": "^1.0.0"
       },
       "dependencies": {
+        "ansi-escapes": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
+          "integrity": "sha1-06ioOzGapneTZisT52HHkRQiMG4="
+        },
+        "async": {
+          "version": "2.6.1",
+          "resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
+          "integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
+          "requires": {
+            "lodash": "^4.17.10"
+          }
+        },
+        "cli-cursor": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
+          "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
+          "requires": {
+            "restore-cursor": "^1.0.1"
+          }
+        },
+        "dateformat": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-2.2.0.tgz",
+          "integrity": "sha1-QGXiATz5+5Ft39gu+1Bq1MZ2kGI="
+        },
+        "deep-extend": {
+          "version": "0.4.2",
+          "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.2.tgz",
+          "integrity": "sha1-SLaZwn4zS/ifEIkr5DL25MfTSn8="
+        },
+        "diff": {
+          "version": "2.2.3",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-2.2.3.tgz",
+          "integrity": "sha1-YOr9DSjukG5Oj/ClLBIpUhAzv5k="
+        },
+        "external-editor": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-1.1.1.tgz",
+          "integrity": "sha1-Etew24UPf/fnCBuvQAVwAGDEYAs=",
+          "requires": {
+            "extend": "^3.0.0",
+            "spawn-sync": "^1.0.15",
+            "tmp": "^0.0.29"
+          }
+        },
+        "gh-got": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/gh-got/-/gh-got-5.0.0.tgz",
+          "integrity": "sha1-7pW+NxBv2HSKlvjR20uuqJ4b+oo=",
+          "requires": {
+            "got": "^6.2.0",
+            "is-plain-obj": "^1.1.0"
+          }
+        },
+        "github-username": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/github-username/-/github-username-3.0.0.tgz",
+          "integrity": "sha1-CnciGbMTB0NCnyRW0L3T21Xc57E=",
+          "requires": {
+            "gh-got": "^5.0.0"
+          }
+        },
+        "globby": {
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
+          "integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
+          "requires": {
+            "array-union": "^1.0.1",
+            "glob": "^7.0.3",
+            "object-assign": "^4.0.1",
+            "pify": "^2.0.0",
+            "pinkie-promise": "^2.0.0"
+          }
+        },
+        "got": {
+          "version": "6.7.1",
+          "resolved": "https://registry.npmjs.org/got/-/got-6.7.1.tgz",
+          "integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
+          "requires": {
+            "create-error-class": "^3.0.0",
+            "duplexer3": "^0.1.4",
+            "get-stream": "^3.0.0",
+            "is-redirect": "^1.0.0",
+            "is-retry-allowed": "^1.0.0",
+            "is-stream": "^1.0.0",
+            "lowercase-keys": "^1.0.0",
+            "safe-buffer": "^5.0.1",
+            "timed-out": "^4.0.0",
+            "unzip-response": "^2.0.1",
+            "url-parse-lax": "^1.0.0"
+          }
+        },
         "ibm-java-codegen-common": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/ibm-java-codegen-common/-/ibm-java-codegen-common-3.0.0.tgz",
           "integrity": "sha1-eagjsvYStNa64EZB2Upf+t3KF+8=",
           "requires": {
-            "handlebars": "4.0.11",
-            "yeoman-generator": "1.1.1"
+            "handlebars": "^4.0.0",
+            "yeoman-generator": "^1.0.0"
+          }
+        },
+        "inquirer": {
+          "version": "1.2.3",
+          "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-1.2.3.tgz",
+          "integrity": "sha1-TexvMvN+97sLLtPx0aXD9UUHSRg=",
+          "requires": {
+            "ansi-escapes": "^1.1.0",
+            "chalk": "^1.0.0",
+            "cli-cursor": "^1.0.1",
+            "cli-width": "^2.0.0",
+            "external-editor": "^1.1.0",
+            "figures": "^1.3.5",
+            "lodash": "^4.3.0",
+            "mute-stream": "0.0.6",
+            "pinkie-promise": "^2.0.0",
+            "run-async": "^2.2.0",
+            "rx": "^4.1.0",
+            "string-width": "^1.0.1",
+            "strip-ansi": "^3.0.0",
+            "through": "^2.3.6"
+          }
+        },
+        "log-symbols": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-1.0.2.tgz",
+          "integrity": "sha1-N2/3tY6jCGoPCfrMdGF+ylAeGhg=",
+          "requires": {
+            "chalk": "^1.0.0"
+          }
+        },
+        "mem-fs-editor": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/mem-fs-editor/-/mem-fs-editor-3.0.2.tgz",
+          "integrity": "sha1-3Qpuryu4prN3QAZ6pUnrUwEFr58=",
+          "requires": {
+            "commondir": "^1.0.1",
+            "deep-extend": "^0.4.0",
+            "ejs": "^2.3.1",
+            "glob": "^7.0.3",
+            "globby": "^6.1.0",
+            "mkdirp": "^0.5.0",
+            "multimatch": "^2.0.0",
+            "rimraf": "^2.2.8",
+            "through2": "^2.0.0",
+            "vinyl": "^2.0.1"
+          }
+        },
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+        },
+        "mute-stream": {
+          "version": "0.0.6",
+          "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.6.tgz",
+          "integrity": "sha1-SJYrGeFp/R38JAs/HnMXYnu8R9s="
+        },
+        "object-assign": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+        },
+        "onetime": {
+          "version": "1.1.0",
+          "resolved": "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+          "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k="
+        },
+        "restore-cursor": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
+          "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
+          "requires": {
+            "exit-hook": "^1.0.0",
+            "onetime": "^1.0.0"
+          }
+        },
+        "tmp": {
+          "version": "0.0.29",
+          "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.29.tgz",
+          "integrity": "sha1-8lEl/w3Z2jzLDC3Tce4SiLuRKMA=",
+          "requires": {
+            "os-tmpdir": "~1.0.1"
+          }
+        },
+        "untildify": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/untildify/-/untildify-2.1.0.tgz",
+          "integrity": "sha1-F+soB5h/dpUunASF/DEdBqgmouA=",
+          "requires": {
+            "os-homedir": "^1.0.0"
+          }
+        },
+        "yeoman-environment": {
+          "version": "1.6.6",
+          "resolved": "https://registry.npmjs.org/yeoman-environment/-/yeoman-environment-1.6.6.tgz",
+          "integrity": "sha1-zYX6Z9FWBg5EDXgH1+988NLR1nE=",
+          "requires": {
+            "chalk": "^1.0.0",
+            "debug": "^2.0.0",
+            "diff": "^2.1.2",
+            "escape-string-regexp": "^1.0.2",
+            "globby": "^4.0.0",
+            "grouped-queue": "^0.3.0",
+            "inquirer": "^1.0.2",
+            "lodash": "^4.11.1",
+            "log-symbols": "^1.0.1",
+            "mem-fs": "^1.1.0",
+            "text-table": "^0.2.0",
+            "untildify": "^2.0.0"
+          },
+          "dependencies": {
+            "glob": {
+              "version": "6.0.4",
+              "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
+              "integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=",
+              "requires": {
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "2 || 3",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
+              }
+            },
+            "globby": {
+              "version": "4.1.0",
+              "resolved": "https://registry.npmjs.org/globby/-/globby-4.1.0.tgz",
+              "integrity": "sha1-CA9UVJ7BuCpsYOYx/ILhIR2+lfg=",
+              "requires": {
+                "array-union": "^1.0.1",
+                "arrify": "^1.0.0",
+                "glob": "^6.0.1",
+                "object-assign": "^4.0.1",
+                "pify": "^2.0.0",
+                "pinkie-promise": "^2.0.0"
+              }
+            }
+          }
+        },
+        "yeoman-generator": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/yeoman-generator/-/yeoman-generator-1.1.1.tgz",
+          "integrity": "sha1-QMK09s374F4ZUv3XKTPw2JJdvfU=",
+          "requires": {
+            "async": "^2.0.0",
+            "chalk": "^1.0.0",
+            "class-extend": "^0.1.0",
+            "cli-table": "^0.3.1",
+            "cross-spawn": "^5.0.1",
+            "dargs": "^5.1.0",
+            "dateformat": "^2.0.0",
+            "debug": "^2.1.0",
+            "detect-conflict": "^1.0.0",
+            "error": "^7.0.2",
+            "find-up": "^2.1.0",
+            "github-username": "^3.0.0",
+            "glob": "^7.0.3",
+            "istextorbinary": "^2.1.0",
+            "lodash": "^4.11.1",
+            "mem-fs-editor": "^3.0.0",
+            "minimist": "^1.2.0",
+            "mkdirp": "^0.5.0",
+            "path-exists": "^3.0.0",
+            "path-is-absolute": "^1.0.0",
+            "pretty-bytes": "^4.0.2",
+            "read-chunk": "^2.0.0",
+            "read-pkg-up": "^2.0.0",
+            "rimraf": "^2.2.0",
+            "run-async": "^2.0.0",
+            "shelljs": "^0.7.0",
+            "text-table": "^0.2.0",
+            "through2": "^2.0.0",
+            "user-home": "^2.0.0",
+            "yeoman-environment": "^1.1.0"
           }
         }
       }
@@ -2080,53 +2670,859 @@
       "resolved": "https://registry.npmjs.org/generator-ibm-java-spring/-/generator-ibm-java-spring-2.2.3.tgz",
       "integrity": "sha1-lieyLxPBq5EHWFZQh63Dv2+jBsE=",
       "requires": {
-        "bluebird": "3.5.1",
-        "extend": "3.0.1",
-        "handlebars": "4.0.11",
+        "bluebird": "^3.5.0",
+        "extend": "^3.0.1",
+        "handlebars": "^4.0.0",
         "ibm-java-codegen-common": "3.0.0",
-        "request": "2.83.0",
-        "unzip2": "0.2.5",
-        "yeoman-assert": "2.2.3",
-        "yeoman-generator": "1.1.1"
+        "request": "^2.81.0",
+        "unzip2": "^0.2.5",
+        "yeoman-assert": "^2.2.2",
+        "yeoman-generator": "^1.0.0"
       },
       "dependencies": {
+        "ansi-escapes": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
+          "integrity": "sha1-06ioOzGapneTZisT52HHkRQiMG4="
+        },
+        "async": {
+          "version": "2.6.1",
+          "resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
+          "integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
+          "requires": {
+            "lodash": "^4.17.10"
+          }
+        },
+        "cli-cursor": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
+          "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
+          "requires": {
+            "restore-cursor": "^1.0.1"
+          }
+        },
+        "dateformat": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-2.2.0.tgz",
+          "integrity": "sha1-QGXiATz5+5Ft39gu+1Bq1MZ2kGI="
+        },
+        "deep-extend": {
+          "version": "0.4.2",
+          "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.2.tgz",
+          "integrity": "sha1-SLaZwn4zS/ifEIkr5DL25MfTSn8="
+        },
+        "diff": {
+          "version": "2.2.3",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-2.2.3.tgz",
+          "integrity": "sha1-YOr9DSjukG5Oj/ClLBIpUhAzv5k="
+        },
+        "external-editor": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-1.1.1.tgz",
+          "integrity": "sha1-Etew24UPf/fnCBuvQAVwAGDEYAs=",
+          "requires": {
+            "extend": "^3.0.0",
+            "spawn-sync": "^1.0.15",
+            "tmp": "^0.0.29"
+          }
+        },
+        "gh-got": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/gh-got/-/gh-got-5.0.0.tgz",
+          "integrity": "sha1-7pW+NxBv2HSKlvjR20uuqJ4b+oo=",
+          "requires": {
+            "got": "^6.2.0",
+            "is-plain-obj": "^1.1.0"
+          }
+        },
+        "github-username": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/github-username/-/github-username-3.0.0.tgz",
+          "integrity": "sha1-CnciGbMTB0NCnyRW0L3T21Xc57E=",
+          "requires": {
+            "gh-got": "^5.0.0"
+          }
+        },
+        "globby": {
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
+          "integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
+          "requires": {
+            "array-union": "^1.0.1",
+            "glob": "^7.0.3",
+            "object-assign": "^4.0.1",
+            "pify": "^2.0.0",
+            "pinkie-promise": "^2.0.0"
+          }
+        },
+        "got": {
+          "version": "6.7.1",
+          "resolved": "https://registry.npmjs.org/got/-/got-6.7.1.tgz",
+          "integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
+          "requires": {
+            "create-error-class": "^3.0.0",
+            "duplexer3": "^0.1.4",
+            "get-stream": "^3.0.0",
+            "is-redirect": "^1.0.0",
+            "is-retry-allowed": "^1.0.0",
+            "is-stream": "^1.0.0",
+            "lowercase-keys": "^1.0.0",
+            "safe-buffer": "^5.0.1",
+            "timed-out": "^4.0.0",
+            "unzip-response": "^2.0.1",
+            "url-parse-lax": "^1.0.0"
+          }
+        },
         "ibm-java-codegen-common": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/ibm-java-codegen-common/-/ibm-java-codegen-common-3.0.0.tgz",
           "integrity": "sha1-eagjsvYStNa64EZB2Upf+t3KF+8=",
           "requires": {
-            "handlebars": "4.0.11",
-            "yeoman-generator": "1.1.1"
+            "handlebars": "^4.0.0",
+            "yeoman-generator": "^1.0.0"
+          }
+        },
+        "inquirer": {
+          "version": "1.2.3",
+          "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-1.2.3.tgz",
+          "integrity": "sha1-TexvMvN+97sLLtPx0aXD9UUHSRg=",
+          "requires": {
+            "ansi-escapes": "^1.1.0",
+            "chalk": "^1.0.0",
+            "cli-cursor": "^1.0.1",
+            "cli-width": "^2.0.0",
+            "external-editor": "^1.1.0",
+            "figures": "^1.3.5",
+            "lodash": "^4.3.0",
+            "mute-stream": "0.0.6",
+            "pinkie-promise": "^2.0.0",
+            "run-async": "^2.2.0",
+            "rx": "^4.1.0",
+            "string-width": "^1.0.1",
+            "strip-ansi": "^3.0.0",
+            "through": "^2.3.6"
+          }
+        },
+        "log-symbols": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-1.0.2.tgz",
+          "integrity": "sha1-N2/3tY6jCGoPCfrMdGF+ylAeGhg=",
+          "requires": {
+            "chalk": "^1.0.0"
+          }
+        },
+        "mem-fs-editor": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/mem-fs-editor/-/mem-fs-editor-3.0.2.tgz",
+          "integrity": "sha1-3Qpuryu4prN3QAZ6pUnrUwEFr58=",
+          "requires": {
+            "commondir": "^1.0.1",
+            "deep-extend": "^0.4.0",
+            "ejs": "^2.3.1",
+            "glob": "^7.0.3",
+            "globby": "^6.1.0",
+            "mkdirp": "^0.5.0",
+            "multimatch": "^2.0.0",
+            "rimraf": "^2.2.8",
+            "through2": "^2.0.0",
+            "vinyl": "^2.0.1"
+          }
+        },
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+        },
+        "mute-stream": {
+          "version": "0.0.6",
+          "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.6.tgz",
+          "integrity": "sha1-SJYrGeFp/R38JAs/HnMXYnu8R9s="
+        },
+        "object-assign": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+        },
+        "onetime": {
+          "version": "1.1.0",
+          "resolved": "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+          "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k="
+        },
+        "restore-cursor": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
+          "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
+          "requires": {
+            "exit-hook": "^1.0.0",
+            "onetime": "^1.0.0"
+          }
+        },
+        "tmp": {
+          "version": "0.0.29",
+          "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.29.tgz",
+          "integrity": "sha1-8lEl/w3Z2jzLDC3Tce4SiLuRKMA=",
+          "requires": {
+            "os-tmpdir": "~1.0.1"
+          }
+        },
+        "untildify": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/untildify/-/untildify-2.1.0.tgz",
+          "integrity": "sha1-F+soB5h/dpUunASF/DEdBqgmouA=",
+          "requires": {
+            "os-homedir": "^1.0.0"
+          }
+        },
+        "yeoman-environment": {
+          "version": "1.6.6",
+          "resolved": "https://registry.npmjs.org/yeoman-environment/-/yeoman-environment-1.6.6.tgz",
+          "integrity": "sha1-zYX6Z9FWBg5EDXgH1+988NLR1nE=",
+          "requires": {
+            "chalk": "^1.0.0",
+            "debug": "^2.0.0",
+            "diff": "^2.1.2",
+            "escape-string-regexp": "^1.0.2",
+            "globby": "^4.0.0",
+            "grouped-queue": "^0.3.0",
+            "inquirer": "^1.0.2",
+            "lodash": "^4.11.1",
+            "log-symbols": "^1.0.1",
+            "mem-fs": "^1.1.0",
+            "text-table": "^0.2.0",
+            "untildify": "^2.0.0"
+          },
+          "dependencies": {
+            "glob": {
+              "version": "6.0.4",
+              "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
+              "integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=",
+              "requires": {
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "2 || 3",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
+              }
+            },
+            "globby": {
+              "version": "4.1.0",
+              "resolved": "https://registry.npmjs.org/globby/-/globby-4.1.0.tgz",
+              "integrity": "sha1-CA9UVJ7BuCpsYOYx/ILhIR2+lfg=",
+              "requires": {
+                "array-union": "^1.0.1",
+                "arrify": "^1.0.0",
+                "glob": "^6.0.1",
+                "object-assign": "^4.0.1",
+                "pify": "^2.0.0",
+                "pinkie-promise": "^2.0.0"
+              }
+            }
+          }
+        },
+        "yeoman-generator": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/yeoman-generator/-/yeoman-generator-1.1.1.tgz",
+          "integrity": "sha1-QMK09s374F4ZUv3XKTPw2JJdvfU=",
+          "requires": {
+            "async": "^2.0.0",
+            "chalk": "^1.0.0",
+            "class-extend": "^0.1.0",
+            "cli-table": "^0.3.1",
+            "cross-spawn": "^5.0.1",
+            "dargs": "^5.1.0",
+            "dateformat": "^2.0.0",
+            "debug": "^2.1.0",
+            "detect-conflict": "^1.0.0",
+            "error": "^7.0.2",
+            "find-up": "^2.1.0",
+            "github-username": "^3.0.0",
+            "glob": "^7.0.3",
+            "istextorbinary": "^2.1.0",
+            "lodash": "^4.11.1",
+            "mem-fs-editor": "^3.0.0",
+            "minimist": "^1.2.0",
+            "mkdirp": "^0.5.0",
+            "path-exists": "^3.0.0",
+            "path-is-absolute": "^1.0.0",
+            "pretty-bytes": "^4.0.2",
+            "read-chunk": "^2.0.0",
+            "read-pkg-up": "^2.0.0",
+            "rimraf": "^2.2.0",
+            "run-async": "^2.0.0",
+            "shelljs": "^0.7.0",
+            "text-table": "^0.2.0",
+            "through2": "^2.0.0",
+            "user-home": "^2.0.0",
+            "yeoman-environment": "^1.1.0"
           }
         }
       }
     },
     "generator-ibm-service-enablement": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/generator-ibm-service-enablement/-/generator-ibm-service-enablement-0.7.0.tgz",
-      "integrity": "sha512-tcUdgeeXf0kDBbMIzbpNt3EPjmK3KlMYLYwfWt3eVv64x0Dp8nIATmgAqyB7GE4AZbH3Xm7h/jvo8nL3LDLlEw==",
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/generator-ibm-service-enablement/-/generator-ibm-service-enablement-1.1.9.tgz",
+      "integrity": "sha512-q1emNRRr14W+zUGU58+IoqlD/ndRSfg/YBh8C7o3xZUa9zt11Jsb6JpW5gD3MvYhv8R2CcskbXrSsS7NwA7pIg==",
       "requires": {
-        "handlebars": "4.0.11",
-        "lodash": "4.17.4",
-        "log4js": "1.1.1",
-        "yeoman-generator": "1.1.1"
+        "handlebars": "^4.0.10",
+        "lodash": "^4.17.4",
+        "log4js": "^1.1.1",
+        "yeoman-generator": "^1.1.1"
+      },
+      "dependencies": {
+        "ansi-escapes": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
+          "integrity": "sha1-06ioOzGapneTZisT52HHkRQiMG4="
+        },
+        "async": {
+          "version": "2.6.1",
+          "resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
+          "integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
+          "requires": {
+            "lodash": "^4.17.10"
+          }
+        },
+        "cli-cursor": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
+          "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
+          "requires": {
+            "restore-cursor": "^1.0.1"
+          }
+        },
+        "dateformat": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-2.2.0.tgz",
+          "integrity": "sha1-QGXiATz5+5Ft39gu+1Bq1MZ2kGI="
+        },
+        "deep-extend": {
+          "version": "0.4.2",
+          "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.2.tgz",
+          "integrity": "sha1-SLaZwn4zS/ifEIkr5DL25MfTSn8="
+        },
+        "diff": {
+          "version": "2.2.3",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-2.2.3.tgz",
+          "integrity": "sha1-YOr9DSjukG5Oj/ClLBIpUhAzv5k="
+        },
+        "external-editor": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-1.1.1.tgz",
+          "integrity": "sha1-Etew24UPf/fnCBuvQAVwAGDEYAs=",
+          "requires": {
+            "extend": "^3.0.0",
+            "spawn-sync": "^1.0.15",
+            "tmp": "^0.0.29"
+          }
+        },
+        "gh-got": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/gh-got/-/gh-got-5.0.0.tgz",
+          "integrity": "sha1-7pW+NxBv2HSKlvjR20uuqJ4b+oo=",
+          "requires": {
+            "got": "^6.2.0",
+            "is-plain-obj": "^1.1.0"
+          }
+        },
+        "github-username": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/github-username/-/github-username-3.0.0.tgz",
+          "integrity": "sha1-CnciGbMTB0NCnyRW0L3T21Xc57E=",
+          "requires": {
+            "gh-got": "^5.0.0"
+          }
+        },
+        "globby": {
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
+          "integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
+          "requires": {
+            "array-union": "^1.0.1",
+            "glob": "^7.0.3",
+            "object-assign": "^4.0.1",
+            "pify": "^2.0.0",
+            "pinkie-promise": "^2.0.0"
+          }
+        },
+        "got": {
+          "version": "6.7.1",
+          "resolved": "https://registry.npmjs.org/got/-/got-6.7.1.tgz",
+          "integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
+          "requires": {
+            "create-error-class": "^3.0.0",
+            "duplexer3": "^0.1.4",
+            "get-stream": "^3.0.0",
+            "is-redirect": "^1.0.0",
+            "is-retry-allowed": "^1.0.0",
+            "is-stream": "^1.0.0",
+            "lowercase-keys": "^1.0.0",
+            "safe-buffer": "^5.0.1",
+            "timed-out": "^4.0.0",
+            "unzip-response": "^2.0.1",
+            "url-parse-lax": "^1.0.0"
+          }
+        },
+        "inquirer": {
+          "version": "1.2.3",
+          "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-1.2.3.tgz",
+          "integrity": "sha1-TexvMvN+97sLLtPx0aXD9UUHSRg=",
+          "requires": {
+            "ansi-escapes": "^1.1.0",
+            "chalk": "^1.0.0",
+            "cli-cursor": "^1.0.1",
+            "cli-width": "^2.0.0",
+            "external-editor": "^1.1.0",
+            "figures": "^1.3.5",
+            "lodash": "^4.3.0",
+            "mute-stream": "0.0.6",
+            "pinkie-promise": "^2.0.0",
+            "run-async": "^2.2.0",
+            "rx": "^4.1.0",
+            "string-width": "^1.0.1",
+            "strip-ansi": "^3.0.0",
+            "through": "^2.3.6"
+          }
+        },
+        "log-symbols": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-1.0.2.tgz",
+          "integrity": "sha1-N2/3tY6jCGoPCfrMdGF+ylAeGhg=",
+          "requires": {
+            "chalk": "^1.0.0"
+          }
+        },
+        "mem-fs-editor": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/mem-fs-editor/-/mem-fs-editor-3.0.2.tgz",
+          "integrity": "sha1-3Qpuryu4prN3QAZ6pUnrUwEFr58=",
+          "requires": {
+            "commondir": "^1.0.1",
+            "deep-extend": "^0.4.0",
+            "ejs": "^2.3.1",
+            "glob": "^7.0.3",
+            "globby": "^6.1.0",
+            "mkdirp": "^0.5.0",
+            "multimatch": "^2.0.0",
+            "rimraf": "^2.2.8",
+            "through2": "^2.0.0",
+            "vinyl": "^2.0.1"
+          }
+        },
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+        },
+        "mute-stream": {
+          "version": "0.0.6",
+          "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.6.tgz",
+          "integrity": "sha1-SJYrGeFp/R38JAs/HnMXYnu8R9s="
+        },
+        "object-assign": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+        },
+        "onetime": {
+          "version": "1.1.0",
+          "resolved": "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+          "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k="
+        },
+        "restore-cursor": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
+          "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
+          "requires": {
+            "exit-hook": "^1.0.0",
+            "onetime": "^1.0.0"
+          }
+        },
+        "tmp": {
+          "version": "0.0.29",
+          "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.29.tgz",
+          "integrity": "sha1-8lEl/w3Z2jzLDC3Tce4SiLuRKMA=",
+          "requires": {
+            "os-tmpdir": "~1.0.1"
+          }
+        },
+        "untildify": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/untildify/-/untildify-2.1.0.tgz",
+          "integrity": "sha1-F+soB5h/dpUunASF/DEdBqgmouA=",
+          "requires": {
+            "os-homedir": "^1.0.0"
+          }
+        },
+        "yeoman-environment": {
+          "version": "1.6.6",
+          "resolved": "https://registry.npmjs.org/yeoman-environment/-/yeoman-environment-1.6.6.tgz",
+          "integrity": "sha1-zYX6Z9FWBg5EDXgH1+988NLR1nE=",
+          "requires": {
+            "chalk": "^1.0.0",
+            "debug": "^2.0.0",
+            "diff": "^2.1.2",
+            "escape-string-regexp": "^1.0.2",
+            "globby": "^4.0.0",
+            "grouped-queue": "^0.3.0",
+            "inquirer": "^1.0.2",
+            "lodash": "^4.11.1",
+            "log-symbols": "^1.0.1",
+            "mem-fs": "^1.1.0",
+            "text-table": "^0.2.0",
+            "untildify": "^2.0.0"
+          },
+          "dependencies": {
+            "glob": {
+              "version": "6.0.4",
+              "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
+              "integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=",
+              "requires": {
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "2 || 3",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
+              }
+            },
+            "globby": {
+              "version": "4.1.0",
+              "resolved": "https://registry.npmjs.org/globby/-/globby-4.1.0.tgz",
+              "integrity": "sha1-CA9UVJ7BuCpsYOYx/ILhIR2+lfg=",
+              "requires": {
+                "array-union": "^1.0.1",
+                "arrify": "^1.0.0",
+                "glob": "^6.0.1",
+                "object-assign": "^4.0.1",
+                "pify": "^2.0.0",
+                "pinkie-promise": "^2.0.0"
+              }
+            }
+          }
+        },
+        "yeoman-generator": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/yeoman-generator/-/yeoman-generator-1.1.1.tgz",
+          "integrity": "sha1-QMK09s374F4ZUv3XKTPw2JJdvfU=",
+          "requires": {
+            "async": "^2.0.0",
+            "chalk": "^1.0.0",
+            "class-extend": "^0.1.0",
+            "cli-table": "^0.3.1",
+            "cross-spawn": "^5.0.1",
+            "dargs": "^5.1.0",
+            "dateformat": "^2.0.0",
+            "debug": "^2.1.0",
+            "detect-conflict": "^1.0.0",
+            "error": "^7.0.2",
+            "find-up": "^2.1.0",
+            "github-username": "^3.0.0",
+            "glob": "^7.0.3",
+            "istextorbinary": "^2.1.0",
+            "lodash": "^4.11.1",
+            "mem-fs-editor": "^3.0.0",
+            "minimist": "^1.2.0",
+            "mkdirp": "^0.5.0",
+            "path-exists": "^3.0.0",
+            "path-is-absolute": "^1.0.0",
+            "pretty-bytes": "^4.0.2",
+            "read-chunk": "^2.0.0",
+            "read-pkg-up": "^2.0.0",
+            "rimraf": "^2.2.0",
+            "run-async": "^2.0.0",
+            "shelljs": "^0.7.0",
+            "text-table": "^0.2.0",
+            "through2": "^2.0.0",
+            "user-home": "^2.0.0",
+            "yeoman-environment": "^1.1.0"
+          }
+        }
       }
     },
     "generator-ibm-usecase-enablement": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/generator-ibm-usecase-enablement/-/generator-ibm-usecase-enablement-3.0.0.tgz",
-      "integrity": "sha512-vkQOWGcywXv1Me+fgDh3I0Uud5TH4jL0S6QJ9W+lNqGwNy4iehnn3ppTqL5JZpSEdls5TMn4gUV9c96MxyvOJw==",
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/generator-ibm-usecase-enablement/-/generator-ibm-usecase-enablement-3.2.2.tgz",
+      "integrity": "sha512-LX9w5Xpa50IVoKINe6VAX/OEbJLruNFyao8lZ3NCBOTScTSaEbpRyFv9lrY/XhOGsNSA9+6g6UA3QpZk2YAJLQ==",
       "requires": {
-        "glob": "7.1.2",
+        "glob": "^7.1.2",
         "guid": "0.0.12",
-        "handlebars": "4.0.11",
-        "js-yaml": "3.11.0",
-        "lodash": "4.17.4",
-        "log4js": "1.1.1",
-        "minimatch": "3.0.4",
-        "q": "1.5.1",
-        "request": "2.83.0",
-        "yeoman-generator": "1.1.1"
+        "handlebars": "^4.0.10",
+        "js-yaml": "^3.10.0",
+        "lodash": "^4.17.4",
+        "log4js": "^1.1.1",
+        "minimatch": "^3.0.4",
+        "q": "^1.5.0",
+        "request": "^2.81.0",
+        "shelljs": "^0.7.0",
+        "yeoman-generator": "^1.1.1"
+      },
+      "dependencies": {
+        "ansi-escapes": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
+          "integrity": "sha1-06ioOzGapneTZisT52HHkRQiMG4="
+        },
+        "async": {
+          "version": "2.6.1",
+          "resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
+          "integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
+          "requires": {
+            "lodash": "^4.17.10"
+          }
+        },
+        "cli-cursor": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
+          "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
+          "requires": {
+            "restore-cursor": "^1.0.1"
+          }
+        },
+        "dateformat": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-2.2.0.tgz",
+          "integrity": "sha1-QGXiATz5+5Ft39gu+1Bq1MZ2kGI="
+        },
+        "deep-extend": {
+          "version": "0.4.2",
+          "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.2.tgz",
+          "integrity": "sha1-SLaZwn4zS/ifEIkr5DL25MfTSn8="
+        },
+        "diff": {
+          "version": "2.2.3",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-2.2.3.tgz",
+          "integrity": "sha1-YOr9DSjukG5Oj/ClLBIpUhAzv5k="
+        },
+        "external-editor": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-1.1.1.tgz",
+          "integrity": "sha1-Etew24UPf/fnCBuvQAVwAGDEYAs=",
+          "requires": {
+            "extend": "^3.0.0",
+            "spawn-sync": "^1.0.15",
+            "tmp": "^0.0.29"
+          }
+        },
+        "gh-got": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/gh-got/-/gh-got-5.0.0.tgz",
+          "integrity": "sha1-7pW+NxBv2HSKlvjR20uuqJ4b+oo=",
+          "requires": {
+            "got": "^6.2.0",
+            "is-plain-obj": "^1.1.0"
+          }
+        },
+        "github-username": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/github-username/-/github-username-3.0.0.tgz",
+          "integrity": "sha1-CnciGbMTB0NCnyRW0L3T21Xc57E=",
+          "requires": {
+            "gh-got": "^5.0.0"
+          }
+        },
+        "globby": {
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
+          "integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
+          "requires": {
+            "array-union": "^1.0.1",
+            "glob": "^7.0.3",
+            "object-assign": "^4.0.1",
+            "pify": "^2.0.0",
+            "pinkie-promise": "^2.0.0"
+          }
+        },
+        "got": {
+          "version": "6.7.1",
+          "resolved": "https://registry.npmjs.org/got/-/got-6.7.1.tgz",
+          "integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
+          "requires": {
+            "create-error-class": "^3.0.0",
+            "duplexer3": "^0.1.4",
+            "get-stream": "^3.0.0",
+            "is-redirect": "^1.0.0",
+            "is-retry-allowed": "^1.0.0",
+            "is-stream": "^1.0.0",
+            "lowercase-keys": "^1.0.0",
+            "safe-buffer": "^5.0.1",
+            "timed-out": "^4.0.0",
+            "unzip-response": "^2.0.1",
+            "url-parse-lax": "^1.0.0"
+          }
+        },
+        "inquirer": {
+          "version": "1.2.3",
+          "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-1.2.3.tgz",
+          "integrity": "sha1-TexvMvN+97sLLtPx0aXD9UUHSRg=",
+          "requires": {
+            "ansi-escapes": "^1.1.0",
+            "chalk": "^1.0.0",
+            "cli-cursor": "^1.0.1",
+            "cli-width": "^2.0.0",
+            "external-editor": "^1.1.0",
+            "figures": "^1.3.5",
+            "lodash": "^4.3.0",
+            "mute-stream": "0.0.6",
+            "pinkie-promise": "^2.0.0",
+            "run-async": "^2.2.0",
+            "rx": "^4.1.0",
+            "string-width": "^1.0.1",
+            "strip-ansi": "^3.0.0",
+            "through": "^2.3.6"
+          }
+        },
+        "log-symbols": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-1.0.2.tgz",
+          "integrity": "sha1-N2/3tY6jCGoPCfrMdGF+ylAeGhg=",
+          "requires": {
+            "chalk": "^1.0.0"
+          }
+        },
+        "mem-fs-editor": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/mem-fs-editor/-/mem-fs-editor-3.0.2.tgz",
+          "integrity": "sha1-3Qpuryu4prN3QAZ6pUnrUwEFr58=",
+          "requires": {
+            "commondir": "^1.0.1",
+            "deep-extend": "^0.4.0",
+            "ejs": "^2.3.1",
+            "glob": "^7.0.3",
+            "globby": "^6.1.0",
+            "mkdirp": "^0.5.0",
+            "multimatch": "^2.0.0",
+            "rimraf": "^2.2.8",
+            "through2": "^2.0.0",
+            "vinyl": "^2.0.1"
+          }
+        },
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+        },
+        "mute-stream": {
+          "version": "0.0.6",
+          "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.6.tgz",
+          "integrity": "sha1-SJYrGeFp/R38JAs/HnMXYnu8R9s="
+        },
+        "object-assign": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+        },
+        "onetime": {
+          "version": "1.1.0",
+          "resolved": "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+          "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k="
+        },
+        "restore-cursor": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
+          "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
+          "requires": {
+            "exit-hook": "^1.0.0",
+            "onetime": "^1.0.0"
+          }
+        },
+        "tmp": {
+          "version": "0.0.29",
+          "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.29.tgz",
+          "integrity": "sha1-8lEl/w3Z2jzLDC3Tce4SiLuRKMA=",
+          "requires": {
+            "os-tmpdir": "~1.0.1"
+          }
+        },
+        "untildify": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/untildify/-/untildify-2.1.0.tgz",
+          "integrity": "sha1-F+soB5h/dpUunASF/DEdBqgmouA=",
+          "requires": {
+            "os-homedir": "^1.0.0"
+          }
+        },
+        "yeoman-environment": {
+          "version": "1.6.6",
+          "resolved": "https://registry.npmjs.org/yeoman-environment/-/yeoman-environment-1.6.6.tgz",
+          "integrity": "sha1-zYX6Z9FWBg5EDXgH1+988NLR1nE=",
+          "requires": {
+            "chalk": "^1.0.0",
+            "debug": "^2.0.0",
+            "diff": "^2.1.2",
+            "escape-string-regexp": "^1.0.2",
+            "globby": "^4.0.0",
+            "grouped-queue": "^0.3.0",
+            "inquirer": "^1.0.2",
+            "lodash": "^4.11.1",
+            "log-symbols": "^1.0.1",
+            "mem-fs": "^1.1.0",
+            "text-table": "^0.2.0",
+            "untildify": "^2.0.0"
+          },
+          "dependencies": {
+            "glob": {
+              "version": "6.0.4",
+              "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
+              "integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=",
+              "requires": {
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "2 || 3",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
+              }
+            },
+            "globby": {
+              "version": "4.1.0",
+              "resolved": "https://registry.npmjs.org/globby/-/globby-4.1.0.tgz",
+              "integrity": "sha1-CA9UVJ7BuCpsYOYx/ILhIR2+lfg=",
+              "requires": {
+                "array-union": "^1.0.1",
+                "arrify": "^1.0.0",
+                "glob": "^6.0.1",
+                "object-assign": "^4.0.1",
+                "pify": "^2.0.0",
+                "pinkie-promise": "^2.0.0"
+              }
+            }
+          }
+        },
+        "yeoman-generator": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/yeoman-generator/-/yeoman-generator-1.1.1.tgz",
+          "integrity": "sha1-QMK09s374F4ZUv3XKTPw2JJdvfU=",
+          "requires": {
+            "async": "^2.0.0",
+            "chalk": "^1.0.0",
+            "class-extend": "^0.1.0",
+            "cli-table": "^0.3.1",
+            "cross-spawn": "^5.0.1",
+            "dargs": "^5.1.0",
+            "dateformat": "^2.0.0",
+            "debug": "^2.1.0",
+            "detect-conflict": "^1.0.0",
+            "error": "^7.0.2",
+            "find-up": "^2.1.0",
+            "github-username": "^3.0.0",
+            "glob": "^7.0.3",
+            "istextorbinary": "^2.1.0",
+            "lodash": "^4.11.1",
+            "mem-fs-editor": "^3.0.0",
+            "minimist": "^1.2.0",
+            "mkdirp": "^0.5.0",
+            "path-exists": "^3.0.0",
+            "path-is-absolute": "^1.0.0",
+            "pretty-bytes": "^4.0.2",
+            "read-chunk": "^2.0.0",
+            "read-pkg-up": "^2.0.0",
+            "rimraf": "^2.2.0",
+            "run-async": "^2.0.0",
+            "shelljs": "^0.7.0",
+            "text-table": "^0.2.0",
+            "through2": "^2.0.0",
+            "user-home": "^2.0.0",
+            "yeoman-environment": "^1.1.0"
+          }
+        }
       }
     },
     "get-caller-file": {
@@ -2139,11 +3535,11 @@
       "resolved": "https://registry.npmjs.org/get-pkg-repo/-/get-pkg-repo-1.4.0.tgz",
       "integrity": "sha1-xztInAbYDMVTbCyFP54FIyBWly0=",
       "requires": {
-        "hosted-git-info": "2.5.0",
-        "meow": "3.7.0",
-        "normalize-package-data": "2.4.0",
-        "parse-github-repo-url": "1.4.1",
-        "through2": "2.0.3"
+        "hosted-git-info": "^2.1.4",
+        "meow": "^3.3.0",
+        "normalize-package-data": "^2.3.0",
+        "parse-github-repo-url": "^1.3.0",
+        "through2": "^2.0.0"
       }
     },
     "get-stdin": {
@@ -2166,7 +3562,7 @@
       "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
       "requires": {
-        "assert-plus": "1.0.0"
+        "assert-plus": "^1.0.0"
       }
     },
     "gh-got": {
@@ -2174,29 +3570,146 @@
       "resolved": "https://registry.npmjs.org/gh-got/-/gh-got-5.0.0.tgz",
       "integrity": "sha1-7pW+NxBv2HSKlvjR20uuqJ4b+oo=",
       "requires": {
-        "got": "6.7.1",
-        "is-plain-obj": "1.1.0"
+        "got": "^6.2.0",
+        "is-plain-obj": "^1.1.0"
       }
     },
     "git-raw-commits": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/git-raw-commits/-/git-raw-commits-1.3.0.tgz",
-      "integrity": "sha1-C8hZbpDV/+c29/VUa9LRL3OrqsY=",
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/git-raw-commits/-/git-raw-commits-1.3.6.tgz",
+      "integrity": "sha512-svsK26tQ8vEKnMshTDatSIQSMDdz8CxIIqKsvPqbtV23Etmw6VNaFAitu8zwZ0VrOne7FztwPyRLxK7/DIUTQg==",
       "requires": {
-        "dargs": "4.1.0",
-        "lodash.template": "4.4.0",
-        "meow": "3.7.0",
-        "split2": "2.2.0",
-        "through2": "2.0.3"
+        "dargs": "^4.0.1",
+        "lodash.template": "^4.0.2",
+        "meow": "^4.0.0",
+        "split2": "^2.0.0",
+        "through2": "^2.0.0"
       },
       "dependencies": {
+        "camelcase": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+          "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
+        },
+        "camelcase-keys": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-4.2.0.tgz",
+          "integrity": "sha1-oqpfsa9oh1glnDLBQUJteJI7m3c=",
+          "requires": {
+            "camelcase": "^4.1.0",
+            "map-obj": "^2.0.0",
+            "quick-lru": "^1.0.0"
+          }
+        },
         "dargs": {
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/dargs/-/dargs-4.1.0.tgz",
           "integrity": "sha1-A6nbtLXC8Tm/FK5T8LiipqhvThc=",
           "requires": {
-            "number-is-nan": "1.0.1"
+            "number-is-nan": "^1.0.0"
           }
+        },
+        "indent-string": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-3.2.0.tgz",
+          "integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok="
+        },
+        "load-json-file": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
+          "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "parse-json": "^4.0.0",
+            "pify": "^3.0.0",
+            "strip-bom": "^3.0.0"
+          }
+        },
+        "map-obj": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-2.0.0.tgz",
+          "integrity": "sha1-plzSkIepJZi4eRJXpSPgISIqwfk="
+        },
+        "meow": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/meow/-/meow-4.0.1.tgz",
+          "integrity": "sha512-xcSBHD5Z86zaOc+781KrupuHAzeGXSLtiAOmBsiLDiPSaYSB6hdew2ng9EBAnZ62jagG9MHAOdxpDi/lWBFJ/A==",
+          "requires": {
+            "camelcase-keys": "^4.0.0",
+            "decamelize-keys": "^1.0.0",
+            "loud-rejection": "^1.0.0",
+            "minimist": "^1.1.3",
+            "minimist-options": "^3.0.1",
+            "normalize-package-data": "^2.3.4",
+            "read-pkg-up": "^3.0.0",
+            "redent": "^2.0.0",
+            "trim-newlines": "^2.0.0"
+          }
+        },
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+        },
+        "parse-json": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+          "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
+          "requires": {
+            "error-ex": "^1.3.1",
+            "json-parse-better-errors": "^1.0.1"
+          }
+        },
+        "path-type": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
+          "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
+          "requires": {
+            "pify": "^3.0.0"
+          }
+        },
+        "pify": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
+        },
+        "read-pkg": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
+          "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
+          "requires": {
+            "load-json-file": "^4.0.0",
+            "normalize-package-data": "^2.3.2",
+            "path-type": "^3.0.0"
+          }
+        },
+        "read-pkg-up": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-3.0.0.tgz",
+          "integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
+          "requires": {
+            "find-up": "^2.0.0",
+            "read-pkg": "^3.0.0"
+          }
+        },
+        "redent": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/redent/-/redent-2.0.0.tgz",
+          "integrity": "sha1-wbIAe0LVfrE4kHmzyDM2OdXhzKo=",
+          "requires": {
+            "indent-string": "^3.0.0",
+            "strip-indent": "^2.0.0"
+          }
+        },
+        "strip-indent": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-2.0.0.tgz",
+          "integrity": "sha1-XvjbKV0B5u1sv3qrlpmNeCJSe2g="
+        },
+        "trim-newlines": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-2.0.0.tgz",
+          "integrity": "sha1-tAPQuRvlDDMd/EuC7s6yLD3hbSA="
         }
       }
     },
@@ -2205,17 +3718,141 @@
       "resolved": "https://registry.npmjs.org/git-remote-origin-url/-/git-remote-origin-url-2.0.0.tgz",
       "integrity": "sha1-UoJlna4hBxRaERJhEq0yFuxfpl8=",
       "requires": {
-        "gitconfiglocal": "1.0.0",
-        "pify": "2.3.0"
+        "gitconfiglocal": "^1.0.0",
+        "pify": "^2.3.0"
       }
     },
     "git-semver-tags": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/git-semver-tags/-/git-semver-tags-1.2.3.tgz",
-      "integrity": "sha1-GItFOIK/nXojr9Mbq6U32rc4jV0=",
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/git-semver-tags/-/git-semver-tags-1.3.6.tgz",
+      "integrity": "sha512-2jHlJnln4D/ECk9FxGEBh3k44wgYdWjWDtMmJPaecjoRmxKo3Y1Lh8GMYuOPu04CHw86NTAODchYjC5pnpMQig==",
       "requires": {
-        "meow": "3.7.0",
-        "semver": "5.4.1"
+        "meow": "^4.0.0",
+        "semver": "^5.5.0"
+      },
+      "dependencies": {
+        "camelcase": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+          "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
+        },
+        "camelcase-keys": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-4.2.0.tgz",
+          "integrity": "sha1-oqpfsa9oh1glnDLBQUJteJI7m3c=",
+          "requires": {
+            "camelcase": "^4.1.0",
+            "map-obj": "^2.0.0",
+            "quick-lru": "^1.0.0"
+          }
+        },
+        "indent-string": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-3.2.0.tgz",
+          "integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok="
+        },
+        "load-json-file": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
+          "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "parse-json": "^4.0.0",
+            "pify": "^3.0.0",
+            "strip-bom": "^3.0.0"
+          }
+        },
+        "map-obj": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-2.0.0.tgz",
+          "integrity": "sha1-plzSkIepJZi4eRJXpSPgISIqwfk="
+        },
+        "meow": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/meow/-/meow-4.0.1.tgz",
+          "integrity": "sha512-xcSBHD5Z86zaOc+781KrupuHAzeGXSLtiAOmBsiLDiPSaYSB6hdew2ng9EBAnZ62jagG9MHAOdxpDi/lWBFJ/A==",
+          "requires": {
+            "camelcase-keys": "^4.0.0",
+            "decamelize-keys": "^1.0.0",
+            "loud-rejection": "^1.0.0",
+            "minimist": "^1.1.3",
+            "minimist-options": "^3.0.1",
+            "normalize-package-data": "^2.3.4",
+            "read-pkg-up": "^3.0.0",
+            "redent": "^2.0.0",
+            "trim-newlines": "^2.0.0"
+          }
+        },
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+        },
+        "parse-json": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+          "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
+          "requires": {
+            "error-ex": "^1.3.1",
+            "json-parse-better-errors": "^1.0.1"
+          }
+        },
+        "path-type": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
+          "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
+          "requires": {
+            "pify": "^3.0.0"
+          }
+        },
+        "pify": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
+        },
+        "read-pkg": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
+          "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
+          "requires": {
+            "load-json-file": "^4.0.0",
+            "normalize-package-data": "^2.3.2",
+            "path-type": "^3.0.0"
+          }
+        },
+        "read-pkg-up": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-3.0.0.tgz",
+          "integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
+          "requires": {
+            "find-up": "^2.0.0",
+            "read-pkg": "^3.0.0"
+          }
+        },
+        "redent": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/redent/-/redent-2.0.0.tgz",
+          "integrity": "sha1-wbIAe0LVfrE4kHmzyDM2OdXhzKo=",
+          "requires": {
+            "indent-string": "^3.0.0",
+            "strip-indent": "^2.0.0"
+          }
+        },
+        "semver": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
+          "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA=="
+        },
+        "strip-indent": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-2.0.0.tgz",
+          "integrity": "sha1-XvjbKV0B5u1sv3qrlpmNeCJSe2g="
+        },
+        "trim-newlines": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-2.0.0.tgz",
+          "integrity": "sha1-tAPQuRvlDDMd/EuC7s6yLD3hbSA="
+        }
       }
     },
     "gitconfiglocal": {
@@ -2223,7 +3860,7 @@
       "resolved": "https://registry.npmjs.org/gitconfiglocal/-/gitconfiglocal-1.0.0.tgz",
       "integrity": "sha1-QdBF84UaXqiPA/JMocYXgRRGS5s=",
       "requires": {
-        "ini": "1.3.5"
+        "ini": "^1.3.2"
       }
     },
     "github-username": {
@@ -2231,7 +3868,7 @@
       "resolved": "https://registry.npmjs.org/github-username/-/github-username-3.0.0.tgz",
       "integrity": "sha1-CnciGbMTB0NCnyRW0L3T21Xc57E=",
       "requires": {
-        "gh-got": "5.0.0"
+        "gh-got": "^5.0.0"
       }
     },
     "glob": {
@@ -2239,12 +3876,12 @@
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
       "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
       "requires": {
-        "fs.realpath": "1.0.0",
-        "inflight": "1.0.6",
-        "inherits": "2.0.3",
-        "minimatch": "3.0.4",
-        "once": "1.4.0",
-        "path-is-absolute": "1.0.1"
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
       }
     },
     "glob-parent": {
@@ -2252,8 +3889,8 @@
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
       "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
       "requires": {
-        "is-glob": "3.1.0",
-        "path-dirname": "1.0.2"
+        "is-glob": "^3.1.0",
+        "path-dirname": "^1.0.0"
       },
       "dependencies": {
         "is-glob": {
@@ -2261,7 +3898,7 @@
           "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
           "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
           "requires": {
-            "is-extglob": "2.1.1"
+            "is-extglob": "^2.1.0"
           }
         }
       }
@@ -2282,11 +3919,11 @@
       "resolved": "https://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
       "integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
       "requires": {
-        "array-union": "1.0.2",
-        "glob": "7.1.2",
-        "object-assign": "4.1.1",
-        "pify": "2.3.0",
-        "pinkie-promise": "2.0.1"
+        "array-union": "^1.0.1",
+        "glob": "^7.0.3",
+        "object-assign": "^4.0.1",
+        "pify": "^2.0.0",
+        "pinkie-promise": "^2.0.0"
       },
       "dependencies": {
         "object-assign": {
@@ -2301,17 +3938,17 @@
       "resolved": "https://registry.npmjs.org/got/-/got-6.7.1.tgz",
       "integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
       "requires": {
-        "create-error-class": "3.0.2",
-        "duplexer3": "0.1.4",
-        "get-stream": "3.0.0",
-        "is-redirect": "1.0.0",
-        "is-retry-allowed": "1.1.0",
-        "is-stream": "1.1.0",
-        "lowercase-keys": "1.0.0",
-        "safe-buffer": "5.1.1",
-        "timed-out": "4.0.1",
-        "unzip-response": "2.0.1",
-        "url-parse-lax": "1.0.0"
+        "create-error-class": "^3.0.0",
+        "duplexer3": "^0.1.4",
+        "get-stream": "^3.0.0",
+        "is-redirect": "^1.0.0",
+        "is-retry-allowed": "^1.0.0",
+        "is-stream": "^1.0.0",
+        "lowercase-keys": "^1.0.0",
+        "safe-buffer": "^5.0.1",
+        "timed-out": "^4.0.0",
+        "unzip-response": "^2.0.1",
+        "url-parse-lax": "^1.0.0"
       }
     },
     "graceful-fs": {
@@ -2330,7 +3967,7 @@
       "resolved": "https://registry.npmjs.org/grouped-queue/-/grouped-queue-0.3.3.tgz",
       "integrity": "sha1-wWfSpTGcWg4JZO9qJbfC34mWyFw=",
       "requires": {
-        "lodash": "4.17.4"
+        "lodash": "^4.17.2"
       }
     },
     "growl": {
@@ -2349,10 +3986,10 @@
       "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.11.tgz",
       "integrity": "sha1-Ywo13+ApS8KB7a5v/F0yn8eYLcw=",
       "requires": {
-        "async": "1.5.2",
-        "optimist": "0.6.1",
-        "source-map": "0.4.4",
-        "uglify-js": "2.8.29"
+        "async": "^1.4.0",
+        "optimist": "^0.6.1",
+        "source-map": "^0.4.4",
+        "uglify-js": "^2.6"
       }
     },
     "har-schema": {
@@ -2365,8 +4002,8 @@
       "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
       "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
       "requires": {
-        "ajv": "5.5.2",
-        "har-schema": "2.0.0"
+        "ajv": "^5.1.0",
+        "har-schema": "^2.0.0"
       }
     },
     "has-ansi": {
@@ -2374,7 +4011,7 @@
       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
       "requires": {
-        "ansi-regex": "2.1.1"
+        "ansi-regex": "^2.0.0"
       }
     },
     "has-flag": {
@@ -2392,7 +4029,7 @@
       "resolved": "https://registry.npmjs.org/has-to-string-tag-x/-/has-to-string-tag-x-1.4.1.tgz",
       "integrity": "sha512-vdbKfmw+3LoOYVr+mtxHaX5a96+0f3DljYd8JOqvOLsf5mw2Otda2qCDT9qRqLAhrjyQ0h7ual5nOiASpsGNFw==",
       "requires": {
-        "has-symbol-support-x": "1.4.2"
+        "has-symbol-support-x": "^1.4.1"
       }
     },
     "has-value": {
@@ -2400,9 +4037,9 @@
       "resolved": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
       "integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
       "requires": {
-        "get-value": "2.0.6",
-        "has-values": "1.0.0",
-        "isobject": "3.0.1"
+        "get-value": "^2.0.6",
+        "has-values": "^1.0.0",
+        "isobject": "^3.0.0"
       }
     },
     "has-values": {
@@ -2410,8 +4047,8 @@
       "resolved": "https://registry.npmjs.org/has-values/-/has-values-1.0.0.tgz",
       "integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
       "requires": {
-        "is-number": "3.0.0",
-        "kind-of": "4.0.0"
+        "is-number": "^3.0.0",
+        "kind-of": "^4.0.0"
       },
       "dependencies": {
         "kind-of": {
@@ -2419,20 +4056,9 @@
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
           "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
           "requires": {
-            "is-buffer": "1.1.6"
+            "is-buffer": "^1.1.5"
           }
         }
-      }
-    },
-    "hawk": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/hawk/-/hawk-6.0.2.tgz",
-      "integrity": "sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==",
-      "requires": {
-        "boom": "4.3.1",
-        "cryptiles": "3.1.2",
-        "hoek": "4.2.0",
-        "sntp": "2.1.0"
       }
     },
     "he": {
@@ -2440,11 +4066,6 @@
       "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
       "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
       "dev": true
-    },
-    "hoek": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.0.tgz",
-      "integrity": "sha512-v0XCLxICi9nPfYrS9RL8HbYnXi9obYAeLbSP00BmnZwCK9+Ih9WOjoZ8YoHCoav2csqn4FOz4Orldsy2dmDwmQ=="
     },
     "hosted-git-info": {
       "version": "2.5.0",
@@ -2456,9 +4077,9 @@
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
       "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
       "requires": {
-        "assert-plus": "1.0.0",
-        "jsprim": "1.4.1",
-        "sshpk": "1.13.1"
+        "assert-plus": "^1.0.0",
+        "jsprim": "^1.2.2",
+        "sshpk": "^1.7.0"
       }
     },
     "ibm-java-codegen-common": {
@@ -2466,8 +4087,277 @@
       "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/ibm-java-codegen-common/-/ibm-java-codegen-common-3.0.1.tgz",
       "integrity": "sha1-NDWTwR17xl6jNImnliartKqlILs=",
       "requires": {
-        "handlebars": "4.0.11",
-        "yeoman-generator": "1.1.1"
+        "handlebars": "^4.0.0",
+        "yeoman-generator": "^1.0.0"
+      },
+      "dependencies": {
+        "ansi-escapes": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
+          "integrity": "sha1-06ioOzGapneTZisT52HHkRQiMG4="
+        },
+        "async": {
+          "version": "2.6.1",
+          "resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
+          "integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
+          "requires": {
+            "lodash": "^4.17.10"
+          }
+        },
+        "cli-cursor": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
+          "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
+          "requires": {
+            "restore-cursor": "^1.0.1"
+          }
+        },
+        "dateformat": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-2.2.0.tgz",
+          "integrity": "sha1-QGXiATz5+5Ft39gu+1Bq1MZ2kGI="
+        },
+        "deep-extend": {
+          "version": "0.4.2",
+          "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.2.tgz",
+          "integrity": "sha1-SLaZwn4zS/ifEIkr5DL25MfTSn8="
+        },
+        "diff": {
+          "version": "2.2.3",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-2.2.3.tgz",
+          "integrity": "sha1-YOr9DSjukG5Oj/ClLBIpUhAzv5k="
+        },
+        "external-editor": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-1.1.1.tgz",
+          "integrity": "sha1-Etew24UPf/fnCBuvQAVwAGDEYAs=",
+          "requires": {
+            "extend": "^3.0.0",
+            "spawn-sync": "^1.0.15",
+            "tmp": "^0.0.29"
+          }
+        },
+        "gh-got": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/gh-got/-/gh-got-5.0.0.tgz",
+          "integrity": "sha1-7pW+NxBv2HSKlvjR20uuqJ4b+oo=",
+          "requires": {
+            "got": "^6.2.0",
+            "is-plain-obj": "^1.1.0"
+          }
+        },
+        "github-username": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/github-username/-/github-username-3.0.0.tgz",
+          "integrity": "sha1-CnciGbMTB0NCnyRW0L3T21Xc57E=",
+          "requires": {
+            "gh-got": "^5.0.0"
+          }
+        },
+        "globby": {
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
+          "integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
+          "requires": {
+            "array-union": "^1.0.1",
+            "glob": "^7.0.3",
+            "object-assign": "^4.0.1",
+            "pify": "^2.0.0",
+            "pinkie-promise": "^2.0.0"
+          }
+        },
+        "got": {
+          "version": "6.7.1",
+          "resolved": "https://registry.npmjs.org/got/-/got-6.7.1.tgz",
+          "integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
+          "requires": {
+            "create-error-class": "^3.0.0",
+            "duplexer3": "^0.1.4",
+            "get-stream": "^3.0.0",
+            "is-redirect": "^1.0.0",
+            "is-retry-allowed": "^1.0.0",
+            "is-stream": "^1.0.0",
+            "lowercase-keys": "^1.0.0",
+            "safe-buffer": "^5.0.1",
+            "timed-out": "^4.0.0",
+            "unzip-response": "^2.0.1",
+            "url-parse-lax": "^1.0.0"
+          }
+        },
+        "inquirer": {
+          "version": "1.2.3",
+          "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-1.2.3.tgz",
+          "integrity": "sha1-TexvMvN+97sLLtPx0aXD9UUHSRg=",
+          "requires": {
+            "ansi-escapes": "^1.1.0",
+            "chalk": "^1.0.0",
+            "cli-cursor": "^1.0.1",
+            "cli-width": "^2.0.0",
+            "external-editor": "^1.1.0",
+            "figures": "^1.3.5",
+            "lodash": "^4.3.0",
+            "mute-stream": "0.0.6",
+            "pinkie-promise": "^2.0.0",
+            "run-async": "^2.2.0",
+            "rx": "^4.1.0",
+            "string-width": "^1.0.1",
+            "strip-ansi": "^3.0.0",
+            "through": "^2.3.6"
+          }
+        },
+        "log-symbols": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-1.0.2.tgz",
+          "integrity": "sha1-N2/3tY6jCGoPCfrMdGF+ylAeGhg=",
+          "requires": {
+            "chalk": "^1.0.0"
+          }
+        },
+        "mem-fs-editor": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/mem-fs-editor/-/mem-fs-editor-3.0.2.tgz",
+          "integrity": "sha1-3Qpuryu4prN3QAZ6pUnrUwEFr58=",
+          "requires": {
+            "commondir": "^1.0.1",
+            "deep-extend": "^0.4.0",
+            "ejs": "^2.3.1",
+            "glob": "^7.0.3",
+            "globby": "^6.1.0",
+            "mkdirp": "^0.5.0",
+            "multimatch": "^2.0.0",
+            "rimraf": "^2.2.8",
+            "through2": "^2.0.0",
+            "vinyl": "^2.0.1"
+          }
+        },
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+        },
+        "mute-stream": {
+          "version": "0.0.6",
+          "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.6.tgz",
+          "integrity": "sha1-SJYrGeFp/R38JAs/HnMXYnu8R9s="
+        },
+        "object-assign": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+        },
+        "onetime": {
+          "version": "1.1.0",
+          "resolved": "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+          "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k="
+        },
+        "restore-cursor": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
+          "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
+          "requires": {
+            "exit-hook": "^1.0.0",
+            "onetime": "^1.0.0"
+          }
+        },
+        "tmp": {
+          "version": "0.0.29",
+          "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.29.tgz",
+          "integrity": "sha1-8lEl/w3Z2jzLDC3Tce4SiLuRKMA=",
+          "requires": {
+            "os-tmpdir": "~1.0.1"
+          }
+        },
+        "untildify": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/untildify/-/untildify-2.1.0.tgz",
+          "integrity": "sha1-F+soB5h/dpUunASF/DEdBqgmouA=",
+          "requires": {
+            "os-homedir": "^1.0.0"
+          }
+        },
+        "yeoman-environment": {
+          "version": "1.6.6",
+          "resolved": "https://registry.npmjs.org/yeoman-environment/-/yeoman-environment-1.6.6.tgz",
+          "integrity": "sha1-zYX6Z9FWBg5EDXgH1+988NLR1nE=",
+          "requires": {
+            "chalk": "^1.0.0",
+            "debug": "^2.0.0",
+            "diff": "^2.1.2",
+            "escape-string-regexp": "^1.0.2",
+            "globby": "^4.0.0",
+            "grouped-queue": "^0.3.0",
+            "inquirer": "^1.0.2",
+            "lodash": "^4.11.1",
+            "log-symbols": "^1.0.1",
+            "mem-fs": "^1.1.0",
+            "text-table": "^0.2.0",
+            "untildify": "^2.0.0"
+          },
+          "dependencies": {
+            "glob": {
+              "version": "6.0.4",
+              "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
+              "integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=",
+              "requires": {
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "2 || 3",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
+              }
+            },
+            "globby": {
+              "version": "4.1.0",
+              "resolved": "https://registry.npmjs.org/globby/-/globby-4.1.0.tgz",
+              "integrity": "sha1-CA9UVJ7BuCpsYOYx/ILhIR2+lfg=",
+              "requires": {
+                "array-union": "^1.0.1",
+                "arrify": "^1.0.0",
+                "glob": "^6.0.1",
+                "object-assign": "^4.0.1",
+                "pify": "^2.0.0",
+                "pinkie-promise": "^2.0.0"
+              }
+            }
+          }
+        },
+        "yeoman-generator": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/yeoman-generator/-/yeoman-generator-1.1.1.tgz",
+          "integrity": "sha1-QMK09s374F4ZUv3XKTPw2JJdvfU=",
+          "requires": {
+            "async": "^2.0.0",
+            "chalk": "^1.0.0",
+            "class-extend": "^0.1.0",
+            "cli-table": "^0.3.1",
+            "cross-spawn": "^5.0.1",
+            "dargs": "^5.1.0",
+            "dateformat": "^2.0.0",
+            "debug": "^2.1.0",
+            "detect-conflict": "^1.0.0",
+            "error": "^7.0.2",
+            "find-up": "^2.1.0",
+            "github-username": "^3.0.0",
+            "glob": "^7.0.3",
+            "istextorbinary": "^2.1.0",
+            "lodash": "^4.11.1",
+            "mem-fs-editor": "^3.0.0",
+            "minimist": "^1.2.0",
+            "mkdirp": "^0.5.0",
+            "path-exists": "^3.0.0",
+            "path-is-absolute": "^1.0.0",
+            "pretty-bytes": "^4.0.2",
+            "read-chunk": "^2.0.0",
+            "read-pkg-up": "^2.0.0",
+            "rimraf": "^2.2.0",
+            "run-async": "^2.0.0",
+            "shelljs": "^0.7.0",
+            "text-table": "^0.2.0",
+            "through2": "^2.0.0",
+            "user-home": "^2.0.0",
+            "yeoman-environment": "^1.1.0"
+          }
+        }
       }
     },
     "iconv-lite": {
@@ -2491,7 +4381,7 @@
       "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
       "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
       "requires": {
-        "repeating": "2.0.1"
+        "repeating": "^2.0.0"
       }
     },
     "inflight": {
@@ -2499,8 +4389,8 @@
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "requires": {
-        "once": "1.4.0",
-        "wrappy": "1.0.2"
+        "once": "^1.3.0",
+        "wrappy": "1"
       }
     },
     "inherits": {
@@ -2518,20 +4408,20 @@
       "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-1.2.3.tgz",
       "integrity": "sha1-TexvMvN+97sLLtPx0aXD9UUHSRg=",
       "requires": {
-        "ansi-escapes": "1.4.0",
-        "chalk": "1.1.3",
-        "cli-cursor": "1.0.2",
-        "cli-width": "2.2.0",
-        "external-editor": "1.1.1",
-        "figures": "1.7.0",
-        "lodash": "4.17.4",
+        "ansi-escapes": "^1.1.0",
+        "chalk": "^1.0.0",
+        "cli-cursor": "^1.0.1",
+        "cli-width": "^2.0.0",
+        "external-editor": "^1.1.0",
+        "figures": "^1.3.5",
+        "lodash": "^4.3.0",
         "mute-stream": "0.0.6",
-        "pinkie-promise": "2.0.1",
-        "run-async": "2.3.0",
-        "rx": "4.1.0",
-        "string-width": "1.0.2",
-        "strip-ansi": "3.0.1",
-        "through": "2.3.8"
+        "pinkie-promise": "^2.0.0",
+        "run-async": "^2.2.0",
+        "rx": "^4.1.0",
+        "string-width": "^1.0.1",
+        "strip-ansi": "^3.0.0",
+        "through": "^2.3.6"
       }
     },
     "interpret": {
@@ -2549,7 +4439,7 @@
       "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
       "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
       "requires": {
-        "kind-of": "3.2.2"
+        "kind-of": "^3.0.2"
       }
     },
     "is-arrayish": {
@@ -2567,7 +4457,7 @@
       "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
       "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
       "requires": {
-        "builtin-modules": "1.1.1"
+        "builtin-modules": "^1.0.0"
       }
     },
     "is-data-descriptor": {
@@ -2575,7 +4465,7 @@
       "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
       "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
       "requires": {
-        "kind-of": "3.2.2"
+        "kind-of": "^3.0.2"
       }
     },
     "is-descriptor": {
@@ -2583,9 +4473,9 @@
       "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
       "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
       "requires": {
-        "is-accessor-descriptor": "0.1.6",
-        "is-data-descriptor": "0.1.4",
-        "kind-of": "5.1.0"
+        "is-accessor-descriptor": "^0.1.6",
+        "is-data-descriptor": "^0.1.4",
+        "kind-of": "^5.0.0"
       },
       "dependencies": {
         "kind-of": {
@@ -2610,7 +4500,7 @@
       "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
       "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
       "requires": {
-        "number-is-nan": "1.0.1"
+        "number-is-nan": "^1.0.0"
       }
     },
     "is-fullwidth-code-point": {
@@ -2618,7 +4508,7 @@
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
       "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
       "requires": {
-        "number-is-nan": "1.0.1"
+        "number-is-nan": "^1.0.0"
       }
     },
     "is-glob": {
@@ -2626,19 +4516,7 @@
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.0.tgz",
       "integrity": "sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=",
       "requires": {
-        "is-extglob": "2.1.1"
-      }
-    },
-    "is-my-json-valid": {
-      "version": "2.17.1",
-      "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.17.1.tgz",
-      "integrity": "sha512-Q2khNw+oBlWuaYvEEHtKSw/pCxD2L5Rc1C+UQme9X6JdRDh7m5D7HkozA0qa3DUkQ6VzCnEm8mVIQPyIRkI5sQ==",
-      "dev": true,
-      "requires": {
-        "generate-function": "2.0.0",
-        "generate-object-property": "1.2.0",
-        "jsonpointer": "4.0.1",
-        "xtend": "4.0.1"
+        "is-extglob": "^2.1.1"
       }
     },
     "is-number": {
@@ -2646,7 +4524,7 @@
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
       "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
       "requires": {
-        "kind-of": "3.2.2"
+        "kind-of": "^3.0.2"
       }
     },
     "is-obj": {
@@ -2664,7 +4542,7 @@
       "resolved": "https://registry.npmjs.org/is-odd/-/is-odd-2.0.0.tgz",
       "integrity": "sha512-OTiixgpZAT1M4NHgS5IguFp/Vz2VI3U7Goh4/HA1adtwyLtSBrxYlcSYkhpAE07s4fKEcjrFxyvtQBND4vFQyQ==",
       "requires": {
-        "is-number": "4.0.0"
+        "is-number": "^4.0.0"
       },
       "dependencies": {
         "is-number": {
@@ -2686,7 +4564,7 @@
       "integrity": "sha512-FjV1RTW48E7CWM7eE/J2NJvAEEVektecDBVBE5Hh3nM1Jd0kvhHtX68Pr3xsDf857xt3Y4AkwVULK1Vku62aaQ==",
       "dev": true,
       "requires": {
-        "is-path-inside": "1.0.1"
+        "is-path-inside": "^1.0.0"
       }
     },
     "is-path-inside": {
@@ -2695,7 +4573,7 @@
       "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
       "dev": true,
       "requires": {
-        "path-is-inside": "1.0.2"
+        "path-is-inside": "^1.0.1"
       }
     },
     "is-plain-obj": {
@@ -2708,19 +4586,13 @@
       "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
       "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
       "requires": {
-        "isobject": "3.0.1"
+        "isobject": "^3.0.1"
       }
     },
     "is-promise": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
       "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o="
-    },
-    "is-property": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
-      "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ=",
-      "dev": true
     },
     "is-redirect": {
       "version": "1.0.0",
@@ -2743,7 +4615,7 @@
       "resolved": "https://registry.npmjs.org/is-scoped/-/is-scoped-1.0.0.tgz",
       "integrity": "sha1-RJypgpnnEwOCViieyytUDcQ3yzA=",
       "requires": {
-        "scoped-regex": "1.0.0"
+        "scoped-regex": "^1.0.0"
       }
     },
     "is-stream": {
@@ -2761,7 +4633,7 @@
       "resolved": "https://registry.npmjs.org/is-text-path/-/is-text-path-1.0.1.tgz",
       "integrity": "sha1-Thqg+1G/vLPpJogAE5cgLBd1tm4=",
       "requires": {
-        "text-extensions": "1.7.0"
+        "text-extensions": "^1.0.0"
       }
     },
     "is-typedarray": {
@@ -2805,13 +4677,13 @@
       "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
     },
     "istextorbinary": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/istextorbinary/-/istextorbinary-2.1.0.tgz",
-      "integrity": "sha1-2+0qb1G+L3R1to+JRlgRFBt1iHQ=",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/istextorbinary/-/istextorbinary-2.2.1.tgz",
+      "integrity": "sha512-TS+hoFl8Z5FAFMK38nhBkdLt44CclNRgDHWeMgsV8ko3nDlr/9UI2Sf839sW7enijf8oKsZYXRvM8g0it9Zmcw==",
       "requires": {
-        "binaryextensions": "2.0.0",
-        "editions": "1.3.3",
-        "textextensions": "2.1.0"
+        "binaryextensions": "2",
+        "editions": "^1.3.3",
+        "textextensions": "2"
       }
     },
     "isurl": {
@@ -2819,8 +4691,8 @@
       "resolved": "https://registry.npmjs.org/isurl/-/isurl-1.0.0.tgz",
       "integrity": "sha512-1P/yWsxPlDtn7QeRD+ULKQPaIaN6yF368GZ2vDfv0AL0NwpStafjWCDDdn0k8wgFMWpVAqG7oJhxHnlud42i9w==",
       "requires": {
-        "has-to-string-tag-x": "1.4.1",
-        "is-object": "1.0.1"
+        "has-to-string-tag-x": "^1.2.0",
+        "is-object": "^1.0.1"
       }
     },
     "js-tokens": {
@@ -2834,8 +4706,8 @@
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.11.0.tgz",
       "integrity": "sha512-saJstZWv7oNeOyBh3+Dx1qWzhW0+e6/8eDzo7p5rDFqxntSztloLtuKu+Ejhtq82jsilwOIZYsCz+lIjthg1Hw==",
       "requires": {
-        "argparse": "1.0.9",
-        "esprima": "4.0.0"
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
       }
     },
     "jsbn": {
@@ -2881,19 +4753,13 @@
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
       "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
       "requires": {
-        "graceful-fs": "4.1.11"
+        "graceful-fs": "^4.1.6"
       }
     },
     "jsonparse": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
       "integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA="
-    },
-    "jsonpointer": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
-      "integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk=",
-      "dev": true
     },
     "jsprim": {
       "version": "1.4.1",
@@ -2916,7 +4782,7 @@
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
       "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
       "requires": {
-        "is-buffer": "1.1.6"
+        "is-buffer": "^1.1.5"
       }
     },
     "lazy-cache": {
@@ -2930,7 +4796,7 @@
       "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
       "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
       "requires": {
-        "invert-kv": "1.0.0"
+        "invert-kv": "^1.0.0"
       }
     },
     "lcov-parse": {
@@ -2945,8 +4811,8 @@
       "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
       "dev": true,
       "requires": {
-        "prelude-ls": "1.1.2",
-        "type-check": "0.3.2"
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2"
       }
     },
     "load-json-file": {
@@ -2954,10 +4820,10 @@
       "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
       "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
       "requires": {
-        "graceful-fs": "4.1.11",
-        "parse-json": "2.2.0",
-        "pify": "2.3.0",
-        "strip-bom": "3.0.0"
+        "graceful-fs": "^4.1.2",
+        "parse-json": "^2.2.0",
+        "pify": "^2.0.0",
+        "strip-bom": "^3.0.0"
       }
     },
     "locate-path": {
@@ -2965,14 +4831,14 @@
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
       "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
       "requires": {
-        "p-locate": "2.0.0",
-        "path-exists": "3.0.0"
+        "p-locate": "^2.0.0",
+        "path-exists": "^3.0.0"
       }
     },
     "lodash": {
-      "version": "4.17.4",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-      "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
+      "version": "4.17.10",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
+      "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
     },
     "lodash._baseassign": {
       "version": "3.2.0",
@@ -2980,8 +4846,8 @@
       "integrity": "sha1-jDigmVAPIVrQnlnxci/QxSv+Ck4=",
       "dev": true,
       "requires": {
-        "lodash._basecopy": "3.0.1",
-        "lodash.keys": "3.1.2"
+        "lodash._basecopy": "^3.0.0",
+        "lodash.keys": "^3.0.0"
       }
     },
     "lodash._basecopy": {
@@ -3019,9 +4885,9 @@
       "integrity": "sha1-1/KEnw29p+BGgruM1yqwIkYd6+c=",
       "dev": true,
       "requires": {
-        "lodash._baseassign": "3.2.0",
-        "lodash._basecreate": "3.0.3",
-        "lodash._isiterateecall": "3.0.9"
+        "lodash._baseassign": "^3.0.0",
+        "lodash._basecreate": "^3.0.0",
+        "lodash._isiterateecall": "^3.0.0"
       }
     },
     "lodash.get": {
@@ -3047,9 +4913,9 @@
       "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
       "dev": true,
       "requires": {
-        "lodash._getnative": "3.9.1",
-        "lodash.isarguments": "3.1.0",
-        "lodash.isarray": "3.0.4"
+        "lodash._getnative": "^3.0.0",
+        "lodash.isarguments": "^3.0.0",
+        "lodash.isarray": "^3.0.0"
       }
     },
     "lodash.template": {
@@ -3057,8 +4923,8 @@
       "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-4.4.0.tgz",
       "integrity": "sha1-5zoDhcg1VZF0bgILmWecaQ5o+6A=",
       "requires": {
-        "lodash._reinterpolate": "3.0.0",
-        "lodash.templatesettings": "4.1.0"
+        "lodash._reinterpolate": "~3.0.0",
+        "lodash.templatesettings": "^4.0.0"
       }
     },
     "lodash.templatesettings": {
@@ -3066,13 +4932,13 @@
       "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-4.1.0.tgz",
       "integrity": "sha1-K01OlbpEDZFf8IvImeRVNmZxMxY=",
       "requires": {
-        "lodash._reinterpolate": "3.0.0"
+        "lodash._reinterpolate": "~3.0.0"
       }
     },
     "log-driver": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/log-driver/-/log-driver-1.2.5.tgz",
-      "integrity": "sha1-euTsJXMC/XkNVXyxDJcQDYV7AFY=",
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/log-driver/-/log-driver-1.2.7.tgz",
+      "integrity": "sha512-U7KCmLdqsGHBLeWqYlFA0V0Sl6P08EE1ZrmA9cxjUE0WVqT9qnyVDPz1kzpFEP0jdJuFnasWIfSd7fsaNXkpbg==",
       "dev": true
     },
     "log-symbols": {
@@ -3080,7 +4946,7 @@
       "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-1.0.2.tgz",
       "integrity": "sha1-N2/3tY6jCGoPCfrMdGF+ylAeGhg=",
       "requires": {
-        "chalk": "1.1.3"
+        "chalk": "^1.0.0"
       }
     },
     "log4js": {
@@ -3088,9 +4954,9 @@
       "resolved": "https://registry.npmjs.org/log4js/-/log4js-1.1.1.tgz",
       "integrity": "sha1-wh0px2BAieTyVYM+f5SzRh3h/0M=",
       "requires": {
-        "debug": "2.6.9",
-        "semver": "5.4.1",
-        "streamroller": "0.4.1"
+        "debug": "^2.2.0",
+        "semver": "^5.3.0",
+        "streamroller": "^0.4.0"
       }
     },
     "lolex": {
@@ -3108,8 +4974,8 @@
       "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
       "integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
       "requires": {
-        "currently-unhandled": "0.4.1",
-        "signal-exit": "3.0.2"
+        "currently-unhandled": "^0.4.1",
+        "signal-exit": "^3.0.0"
       }
     },
     "lowercase-keys": {
@@ -3122,8 +4988,8 @@
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
       "integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
       "requires": {
-        "pseudomap": "1.0.2",
-        "yallist": "2.1.2"
+        "pseudomap": "^1.0.2",
+        "yallist": "^2.1.2"
       }
     },
     "make-dir": {
@@ -3131,7 +4997,7 @@
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
       "integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
       "requires": {
-        "pify": "3.0.0"
+        "pify": "^3.0.0"
       },
       "dependencies": {
         "pify": {
@@ -3156,7 +5022,7 @@
       "resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
       "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
       "requires": {
-        "object-visit": "1.0.1"
+        "object-visit": "^1.0.0"
       }
     },
     "match-stream": {
@@ -3164,8 +5030,8 @@
       "resolved": "https://registry.npmjs.org/match-stream/-/match-stream-0.0.2.tgz",
       "integrity": "sha1-mesFAJOzTf+t5CG5rAtBCpz6F88=",
       "requires": {
-        "buffers": "0.1.1",
-        "readable-stream": "1.0.34"
+        "buffers": "~0.1.1",
+        "readable-stream": "~1.0.0"
       },
       "dependencies": {
         "isarray": {
@@ -3178,10 +5044,10 @@
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
             "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
+            "string_decoder": "~0.10.x"
           }
         },
         "string_decoder": {
@@ -3196,7 +5062,7 @@
       "resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
       "integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
       "requires": {
-        "mimic-fn": "1.1.0"
+        "mimic-fn": "^1.0.0"
       }
     },
     "mem-fs": {
@@ -3204,9 +5070,9 @@
       "resolved": "https://registry.npmjs.org/mem-fs/-/mem-fs-1.1.3.tgz",
       "integrity": "sha1-uK6NLj/Lb10/kWXBLUVRoGXZicw=",
       "requires": {
-        "through2": "2.0.3",
-        "vinyl": "1.2.0",
-        "vinyl-file": "2.0.0"
+        "through2": "^2.0.0",
+        "vinyl": "^1.1.0",
+        "vinyl-file": "^2.0.0"
       },
       "dependencies": {
         "clone": {
@@ -3229,8 +5095,8 @@
           "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-1.2.0.tgz",
           "integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
           "requires": {
-            "clone": "1.0.3",
-            "clone-stats": "0.0.1",
+            "clone": "^1.0.0",
+            "clone-stats": "^0.0.1",
             "replace-ext": "0.0.1"
           }
         }
@@ -3241,16 +5107,16 @@
       "resolved": "https://registry.npmjs.org/mem-fs-editor/-/mem-fs-editor-3.0.2.tgz",
       "integrity": "sha1-3Qpuryu4prN3QAZ6pUnrUwEFr58=",
       "requires": {
-        "commondir": "1.0.1",
-        "deep-extend": "0.4.2",
-        "ejs": "2.5.7",
-        "glob": "7.1.2",
-        "globby": "6.1.0",
-        "mkdirp": "0.5.1",
-        "multimatch": "2.1.0",
-        "rimraf": "2.6.2",
-        "through2": "2.0.3",
-        "vinyl": "2.1.0"
+        "commondir": "^1.0.1",
+        "deep-extend": "^0.4.0",
+        "ejs": "^2.3.1",
+        "glob": "^7.0.3",
+        "globby": "^6.1.0",
+        "mkdirp": "^0.5.0",
+        "multimatch": "^2.0.0",
+        "rimraf": "^2.2.8",
+        "through2": "^2.0.0",
+        "vinyl": "^2.0.1"
       }
     },
     "meow": {
@@ -3258,16 +5124,16 @@
       "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
       "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
       "requires": {
-        "camelcase-keys": "2.1.0",
-        "decamelize": "1.2.0",
-        "loud-rejection": "1.6.0",
-        "map-obj": "1.0.1",
-        "minimist": "1.2.0",
-        "normalize-package-data": "2.4.0",
-        "object-assign": "4.1.1",
-        "read-pkg-up": "1.0.1",
-        "redent": "1.0.0",
-        "trim-newlines": "1.0.0"
+        "camelcase-keys": "^2.0.0",
+        "decamelize": "^1.1.2",
+        "loud-rejection": "^1.0.0",
+        "map-obj": "^1.0.1",
+        "minimist": "^1.1.3",
+        "normalize-package-data": "^2.3.4",
+        "object-assign": "^4.0.1",
+        "read-pkg-up": "^1.0.1",
+        "redent": "^1.0.0",
+        "trim-newlines": "^1.0.0"
       },
       "dependencies": {
         "find-up": {
@@ -3275,8 +5141,8 @@
           "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
           "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
           "requires": {
-            "path-exists": "2.1.0",
-            "pinkie-promise": "2.0.1"
+            "path-exists": "^2.0.0",
+            "pinkie-promise": "^2.0.0"
           }
         },
         "load-json-file": {
@@ -3284,11 +5150,11 @@
           "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
           "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
           "requires": {
-            "graceful-fs": "4.1.11",
-            "parse-json": "2.2.0",
-            "pify": "2.3.0",
-            "pinkie-promise": "2.0.1",
-            "strip-bom": "2.0.0"
+            "graceful-fs": "^4.1.2",
+            "parse-json": "^2.2.0",
+            "pify": "^2.0.0",
+            "pinkie-promise": "^2.0.0",
+            "strip-bom": "^2.0.0"
           }
         },
         "minimist": {
@@ -3306,7 +5172,7 @@
           "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
           "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
           "requires": {
-            "pinkie-promise": "2.0.1"
+            "pinkie-promise": "^2.0.0"
           }
         },
         "path-type": {
@@ -3314,9 +5180,9 @@
           "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
           "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
           "requires": {
-            "graceful-fs": "4.1.11",
-            "pify": "2.3.0",
-            "pinkie-promise": "2.0.1"
+            "graceful-fs": "^4.1.2",
+            "pify": "^2.0.0",
+            "pinkie-promise": "^2.0.0"
           }
         },
         "read-pkg": {
@@ -3324,9 +5190,9 @@
           "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
           "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
           "requires": {
-            "load-json-file": "1.1.0",
-            "normalize-package-data": "2.4.0",
-            "path-type": "1.1.0"
+            "load-json-file": "^1.0.0",
+            "normalize-package-data": "^2.3.2",
+            "path-type": "^1.0.0"
           }
         },
         "read-pkg-up": {
@@ -3334,8 +5200,8 @@
           "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
           "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
           "requires": {
-            "find-up": "1.1.2",
-            "read-pkg": "1.1.0"
+            "find-up": "^1.0.0",
+            "read-pkg": "^1.0.0"
           }
         },
         "strip-bom": {
@@ -3343,7 +5209,7 @@
           "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
           "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
           "requires": {
-            "is-utf8": "0.2.1"
+            "is-utf8": "^0.2.0"
           }
         }
       }
@@ -3358,19 +5224,19 @@
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
       "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
       "requires": {
-        "arr-diff": "4.0.0",
-        "array-unique": "0.3.2",
-        "braces": "2.3.2",
-        "define-property": "2.0.2",
-        "extend-shallow": "3.0.2",
-        "extglob": "2.0.4",
-        "fragment-cache": "0.2.1",
-        "kind-of": "6.0.2",
-        "nanomatch": "1.2.9",
-        "object.pick": "1.3.0",
-        "regex-not": "1.0.2",
-        "snapdragon": "0.8.2",
-        "to-regex": "3.0.2"
+        "arr-diff": "^4.0.0",
+        "array-unique": "^0.3.2",
+        "braces": "^2.3.1",
+        "define-property": "^2.0.2",
+        "extend-shallow": "^3.0.2",
+        "extglob": "^2.0.4",
+        "fragment-cache": "^0.2.1",
+        "kind-of": "^6.0.2",
+        "nanomatch": "^1.2.9",
+        "object.pick": "^1.3.0",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.2"
       },
       "dependencies": {
         "kind-of": {
@@ -3381,16 +5247,16 @@
       }
     },
     "mime-db": {
-      "version": "1.30.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.30.0.tgz",
-      "integrity": "sha1-dMZD2i3Z1qRTmZY0ZbJtXKfXHwE="
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.33.0.tgz",
+      "integrity": "sha512-BHJ/EKruNIqJf/QahvxwQZXKygOQ256myeN/Ew+THcAa5q+PjyTTMMeNQC4DZw5AwfvelsUrA6B67NKMqXDbzQ=="
     },
     "mime-types": {
-      "version": "2.1.17",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.17.tgz",
-      "integrity": "sha1-Cdejk/A+mVp5+K+Fe3Cp4KsWVXo=",
+      "version": "2.1.18",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
+      "integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
       "requires": {
-        "mime-db": "1.30.0"
+        "mime-db": "~1.33.0"
       }
     },
     "mimic-fn": {
@@ -3408,7 +5274,7 @@
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "requires": {
-        "brace-expansion": "1.1.8"
+        "brace-expansion": "^1.1.7"
       }
     },
     "minimist": {
@@ -3416,13 +5282,22 @@
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
       "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8="
     },
+    "minimist-options": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/minimist-options/-/minimist-options-3.0.2.tgz",
+      "integrity": "sha512-FyBrT/d0d4+uiZRbqznPXqw3IpZZG3gl3wKWiX784FycUKVwBt0uLBFkQrtE4tZOrgo78nZp2jnKz3L65T5LdQ==",
+      "requires": {
+        "arrify": "^1.0.1",
+        "is-plain-obj": "^1.1.0"
+      }
+    },
     "mixin-deep": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.1.tgz",
       "integrity": "sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==",
       "requires": {
-        "for-in": "1.0.2",
-        "is-extendable": "1.0.1"
+        "for-in": "^1.0.2",
+        "is-extendable": "^1.0.1"
       },
       "dependencies": {
         "is-extendable": {
@@ -3430,7 +5305,7 @@
           "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
           "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
           "requires": {
-            "is-plain-object": "2.0.4"
+            "is-plain-object": "^2.0.4"
           }
         }
       }
@@ -3476,7 +5351,7 @@
           "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
           "dev": true,
           "requires": {
-            "graceful-readlink": "1.0.1"
+            "graceful-readlink": ">= 1.0.0"
           }
         },
         "debug": {
@@ -3500,12 +5375,12 @@
           "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
           "dev": true,
           "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.2",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         },
         "has-flag": {
@@ -3520,7 +5395,7 @@
           "integrity": "sha1-cqJiiU2dQIuVbKBf83su2KbiotU=",
           "dev": true,
           "requires": {
-            "has-flag": "1.0.0"
+            "has-flag": "^1.0.0"
           }
         }
       }
@@ -3531,8 +5406,8 @@
       "integrity": "sha1-zH8/TTL0eFIJQdhSq7ZNmYhYfYI=",
       "dev": true,
       "requires": {
-        "debug": "3.1.0",
-        "lodash": "4.17.4"
+        "debug": "^3.1.0",
+        "lodash": "^4.16.4"
       },
       "dependencies": {
         "debug": {
@@ -3547,9 +5422,9 @@
       }
     },
     "modify-values": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/modify-values/-/modify-values-1.0.0.tgz",
-      "integrity": "sha1-4rbN65zhn5kxelNyLz2/XfXqqrI="
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/modify-values/-/modify-values-1.0.1.tgz",
+      "integrity": "sha512-xV2bxeN6F7oYjZWTe/YPAy6MN2M+sL4u/Rlm2AHCIVGfo2p1yGmBHQ6vHehl4bRTZBdHu3TSkWdYgkwpYzAGSw=="
     },
     "ms": {
       "version": "2.0.0",
@@ -3561,10 +5436,10 @@
       "resolved": "https://registry.npmjs.org/multimatch/-/multimatch-2.1.0.tgz",
       "integrity": "sha1-nHkGoi+0wCkZ4vX3UWG0zb1LKis=",
       "requires": {
-        "array-differ": "1.0.0",
-        "array-union": "1.0.2",
-        "arrify": "1.0.1",
-        "minimatch": "3.0.4"
+        "array-differ": "^1.0.0",
+        "array-union": "^1.0.1",
+        "arrify": "^1.0.0",
+        "minimatch": "^3.0.0"
       }
     },
     "mute-stream": {
@@ -3577,18 +5452,18 @@
       "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.9.tgz",
       "integrity": "sha512-n8R9bS8yQ6eSXaV6jHUpKzD8gLsin02w1HSFiegwrs9E098Ylhw5jdyKPaYqvHknHaSCKTPp7C8dGCQ0q9koXA==",
       "requires": {
-        "arr-diff": "4.0.0",
-        "array-unique": "0.3.2",
-        "define-property": "2.0.2",
-        "extend-shallow": "3.0.2",
-        "fragment-cache": "0.2.1",
-        "is-odd": "2.0.0",
-        "is-windows": "1.0.2",
-        "kind-of": "6.0.2",
-        "object.pick": "1.3.0",
-        "regex-not": "1.0.2",
-        "snapdragon": "0.8.2",
-        "to-regex": "3.0.2"
+        "arr-diff": "^4.0.0",
+        "array-unique": "^0.3.2",
+        "define-property": "^2.0.2",
+        "extend-shallow": "^3.0.2",
+        "fragment-cache": "^0.2.1",
+        "is-odd": "^2.0.0",
+        "is-windows": "^1.0.2",
+        "kind-of": "^6.0.2",
+        "object.pick": "^1.3.0",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.1"
       },
       "dependencies": {
         "kind-of": {
@@ -3619,11 +5494,11 @@
       "resolved": "https://registry.npmjs.org/nise/-/nise-1.3.3.tgz",
       "integrity": "sha512-v1J/FLUB9PfGqZLGDBhQqODkbLotP0WtLo9R4EJY2PPu5f5Xg4o0rA8FDlmrjFSv9vBBKcfnOSpfYYuu5RTHqg==",
       "requires": {
-        "@sinonjs/formatio": "2.0.0",
-        "just-extend": "1.1.27",
-        "lolex": "2.6.0",
-        "path-to-regexp": "1.7.0",
-        "text-encoding": "0.6.4"
+        "@sinonjs/formatio": "^2.0.0",
+        "just-extend": "^1.1.27",
+        "lolex": "^2.3.2",
+        "path-to-regexp": "^1.7.0",
+        "text-encoding": "^0.6.4"
       }
     },
     "normalize-package-data": {
@@ -3631,10 +5506,10 @@
       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
       "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
       "requires": {
-        "hosted-git-info": "2.5.0",
-        "is-builtin-module": "1.0.0",
-        "semver": "5.4.1",
-        "validate-npm-package-license": "3.0.1"
+        "hosted-git-info": "^2.1.4",
+        "is-builtin-module": "^1.0.0",
+        "semver": "2 || 3 || 4 || 5",
+        "validate-npm-package-license": "^3.0.1"
       }
     },
     "npm": {
@@ -3642,133 +5517,133 @@
       "resolved": "https://registry.npmjs.org/npm/-/npm-6.0.1.tgz",
       "integrity": "sha512-N3uW8jeIXIBp5G3Q6Yu3TTN1ss6BUWuDTHk2JkdTUGaUf0AwKdtVs63O5B75C9NNn7y/7tMpkMCE++xpRhjUBw==",
       "requires": {
-        "JSONStream": "1.3.2",
-        "abbrev": "1.1.1",
-        "ansi-regex": "3.0.0",
-        "ansicolors": "0.3.2",
-        "ansistyles": "0.1.3",
-        "aproba": "1.2.0",
-        "archy": "1.0.0",
-        "bin-links": "1.1.2",
-        "bluebird": "3.5.1",
-        "byte-size": "4.0.2",
-        "cacache": "11.0.1",
-        "call-limit": "1.1.0",
-        "chownr": "1.0.1",
-        "cli-columns": "3.1.2",
-        "cli-table2": "0.2.0",
-        "cmd-shim": "2.0.2",
-        "columnify": "1.5.4",
-        "config-chain": "1.1.11",
-        "debuglog": "1.0.1",
-        "detect-indent": "5.0.0",
-        "detect-newline": "2.1.0",
-        "dezalgo": "1.0.3",
-        "editor": "1.0.0",
-        "figgy-pudding": "3.1.0",
-        "find-npm-prefix": "1.0.2",
-        "fs-vacuum": "1.2.10",
-        "fs-write-stream-atomic": "1.0.10",
-        "gentle-fs": "2.0.1",
-        "glob": "7.1.2",
-        "graceful-fs": "4.1.11",
-        "has-unicode": "2.0.1",
-        "hosted-git-info": "2.6.0",
-        "iferr": "1.0.0",
-        "imurmurhash": "0.1.4",
-        "inflight": "1.0.6",
-        "inherits": "2.0.3",
-        "ini": "1.3.5",
-        "init-package-json": "1.10.3",
-        "is-cidr": "2.0.5",
-        "json-parse-better-errors": "1.0.2",
-        "lazy-property": "1.0.0",
-        "libcipm": "1.6.2",
-        "libnpmhook": "4.0.1",
-        "libnpx": "10.2.0",
-        "lock-verify": "2.0.2",
-        "lockfile": "1.0.4",
-        "lodash._baseindexof": "3.1.0",
-        "lodash._baseuniq": "4.6.0",
-        "lodash._bindcallback": "3.0.1",
-        "lodash._cacheindexof": "3.0.2",
-        "lodash._createcache": "3.1.2",
-        "lodash._getnative": "3.9.1",
-        "lodash.clonedeep": "4.5.0",
-        "lodash.restparam": "3.6.1",
-        "lodash.union": "4.6.0",
-        "lodash.uniq": "4.5.0",
-        "lodash.without": "4.4.0",
-        "lru-cache": "4.1.2",
-        "meant": "1.0.1",
-        "mississippi": "3.0.0",
-        "mkdirp": "0.5.1",
-        "move-concurrently": "1.0.1",
-        "node-gyp": "3.6.2",
-        "nopt": "4.0.1",
-        "normalize-package-data": "2.4.0",
-        "npm-audit-report": "1.0.8",
-        "npm-cache-filename": "1.0.2",
-        "npm-install-checks": "3.0.0",
-        "npm-lifecycle": "2.0.1",
-        "npm-package-arg": "6.1.0",
-        "npm-packlist": "1.1.10",
-        "npm-pick-manifest": "2.1.0",
-        "npm-profile": "3.0.1",
-        "npm-registry-client": "8.5.1",
-        "npm-registry-fetch": "1.1.0",
-        "npm-user-validate": "1.0.0",
-        "npmlog": "4.1.2",
-        "once": "1.4.0",
-        "opener": "1.4.3",
-        "osenv": "0.1.5",
-        "pacote": "8.1.1",
-        "path-is-inside": "1.0.2",
-        "promise-inflight": "1.0.1",
-        "qrcode-terminal": "0.12.0",
-        "query-string": "6.1.0",
-        "qw": "1.0.1",
-        "read": "1.0.7",
-        "read-cmd-shim": "1.0.1",
-        "read-installed": "4.0.3",
-        "read-package-json": "2.0.13",
-        "read-package-tree": "5.2.1",
-        "readable-stream": "2.3.6",
-        "readdir-scoped-modules": "1.0.2",
-        "request": "2.85.0",
-        "retry": "0.12.0",
-        "rimraf": "2.6.2",
-        "safe-buffer": "5.1.2",
-        "semver": "5.5.0",
-        "sha": "2.0.1",
-        "slide": "1.1.6",
-        "sorted-object": "2.0.1",
-        "sorted-union-stream": "2.1.3",
-        "ssri": "6.0.0",
-        "strip-ansi": "4.0.0",
-        "tar": "4.4.2",
-        "text-table": "0.2.0",
-        "tiny-relative-date": "1.3.0",
+        "JSONStream": "^1.3.2",
+        "abbrev": "~1.1.1",
+        "ansi-regex": "~3.0.0",
+        "ansicolors": "~0.3.2",
+        "ansistyles": "~0.1.3",
+        "aproba": "~1.2.0",
+        "archy": "~1.0.0",
+        "bin-links": "^1.1.2",
+        "bluebird": "~3.5.1",
+        "byte-size": "^4.0.2",
+        "cacache": "^11.0.1",
+        "call-limit": "~1.1.0",
+        "chownr": "~1.0.1",
+        "cli-columns": "^3.1.2",
+        "cli-table2": "~0.2.0",
+        "cmd-shim": "~2.0.2",
+        "columnify": "~1.5.4",
+        "config-chain": "~1.1.11",
+        "debuglog": "*",
+        "detect-indent": "~5.0.0",
+        "detect-newline": "^2.1.0",
+        "dezalgo": "~1.0.3",
+        "editor": "~1.0.0",
+        "figgy-pudding": "^3.1.0",
+        "find-npm-prefix": "^1.0.2",
+        "fs-vacuum": "~1.2.10",
+        "fs-write-stream-atomic": "~1.0.10",
+        "gentle-fs": "^2.0.1",
+        "glob": "~7.1.2",
+        "graceful-fs": "~4.1.11",
+        "has-unicode": "~2.0.1",
+        "hosted-git-info": "^2.6.0",
+        "iferr": "^1.0.0",
+        "imurmurhash": "*",
+        "inflight": "~1.0.6",
+        "inherits": "~2.0.3",
+        "ini": "^1.3.5",
+        "init-package-json": "^1.10.3",
+        "is-cidr": "^2.0.5",
+        "json-parse-better-errors": "^1.0.2",
+        "lazy-property": "~1.0.0",
+        "libcipm": "^1.6.2",
+        "libnpmhook": "^4.0.1",
+        "libnpx": "^10.2.0",
+        "lock-verify": "^2.0.2",
+        "lockfile": "^1.0.4",
+        "lodash._baseindexof": "*",
+        "lodash._baseuniq": "~4.6.0",
+        "lodash._bindcallback": "*",
+        "lodash._cacheindexof": "*",
+        "lodash._createcache": "*",
+        "lodash._getnative": "*",
+        "lodash.clonedeep": "~4.5.0",
+        "lodash.restparam": "*",
+        "lodash.union": "~4.6.0",
+        "lodash.uniq": "~4.5.0",
+        "lodash.without": "~4.4.0",
+        "lru-cache": "^4.1.2",
+        "meant": "~1.0.1",
+        "mississippi": "^3.0.0",
+        "mkdirp": "~0.5.1",
+        "move-concurrently": "^1.0.1",
+        "node-gyp": "^3.6.2",
+        "nopt": "~4.0.1",
+        "normalize-package-data": "~2.4.0",
+        "npm-audit-report": "^1.0.8",
+        "npm-cache-filename": "~1.0.2",
+        "npm-install-checks": "~3.0.0",
+        "npm-lifecycle": "^2.0.1",
+        "npm-package-arg": "^6.1.0",
+        "npm-packlist": "~1.1.10",
+        "npm-pick-manifest": "^2.1.0",
+        "npm-profile": "^3.0.1",
+        "npm-registry-client": "^8.5.1",
+        "npm-registry-fetch": "^1.1.0",
+        "npm-user-validate": "~1.0.0",
+        "npmlog": "~4.1.2",
+        "once": "~1.4.0",
+        "opener": "~1.4.3",
+        "osenv": "^0.1.5",
+        "pacote": "^8.1.1",
+        "path-is-inside": "~1.0.2",
+        "promise-inflight": "~1.0.1",
+        "qrcode-terminal": "^0.12.0",
+        "query-string": "^6.1.0",
+        "qw": "~1.0.1",
+        "read": "~1.0.7",
+        "read-cmd-shim": "~1.0.1",
+        "read-installed": "~4.0.3",
+        "read-package-json": "^2.0.13",
+        "read-package-tree": "^5.2.1",
+        "readable-stream": "^2.3.6",
+        "readdir-scoped-modules": "*",
+        "request": "^2.85.0",
+        "retry": "^0.12.0",
+        "rimraf": "~2.6.2",
+        "safe-buffer": "^5.1.2",
+        "semver": "^5.5.0",
+        "sha": "~2.0.1",
+        "slide": "~1.1.6",
+        "sorted-object": "~2.0.1",
+        "sorted-union-stream": "~2.1.3",
+        "ssri": "^6.0.0",
+        "strip-ansi": "~4.0.0",
+        "tar": "^4.4.2",
+        "text-table": "~0.2.0",
+        "tiny-relative-date": "^1.3.0",
         "uid-number": "0.0.6",
-        "umask": "1.1.0",
-        "unique-filename": "1.1.0",
-        "unpipe": "1.0.0",
-        "update-notifier": "2.5.0",
-        "uuid": "3.2.1",
-        "validate-npm-package-license": "3.0.3",
-        "validate-npm-package-name": "3.0.0",
-        "which": "1.3.0",
-        "worker-farm": "1.6.0",
-        "wrappy": "1.0.2",
-        "write-file-atomic": "2.3.0"
+        "umask": "~1.1.0",
+        "unique-filename": "~1.1.0",
+        "unpipe": "~1.0.0",
+        "update-notifier": "^2.5.0",
+        "uuid": "^3.2.1",
+        "validate-npm-package-license": "^3.0.3",
+        "validate-npm-package-name": "~3.0.0",
+        "which": "~1.3.0",
+        "worker-farm": "^1.6.0",
+        "wrappy": "~1.0.2",
+        "write-file-atomic": "^2.3.0"
       },
       "dependencies": {
         "JSONStream": {
           "version": "1.3.2",
           "bundled": true,
           "requires": {
-            "jsonparse": "1.3.1",
-            "through": "2.3.8"
+            "jsonparse": "^1.2.0",
+            "through": ">=2.2.7 <3"
           },
           "dependencies": {
             "jsonparse": {
@@ -3809,11 +5684,11 @@
           "version": "1.1.2",
           "bundled": true,
           "requires": {
-            "bluebird": "3.5.1",
-            "cmd-shim": "2.0.2",
-            "gentle-fs": "2.0.1",
-            "graceful-fs": "4.1.11",
-            "write-file-atomic": "2.3.0"
+            "bluebird": "^3.5.0",
+            "cmd-shim": "^2.0.2",
+            "gentle-fs": "^2.0.0",
+            "graceful-fs": "^4.1.11",
+            "write-file-atomic": "^2.3.0"
           }
         },
         "bluebird": {
@@ -3828,20 +5703,20 @@
           "version": "11.0.1",
           "bundled": true,
           "requires": {
-            "bluebird": "3.5.1",
-            "chownr": "1.0.1",
-            "figgy-pudding": "3.1.0",
-            "glob": "7.1.2",
-            "graceful-fs": "4.1.11",
-            "lru-cache": "4.1.2",
-            "mississippi": "3.0.0",
-            "mkdirp": "0.5.1",
-            "move-concurrently": "1.0.1",
-            "promise-inflight": "1.0.1",
-            "rimraf": "2.6.2",
-            "ssri": "6.0.0",
-            "unique-filename": "1.1.0",
-            "y18n": "4.0.0"
+            "bluebird": "^3.5.1",
+            "chownr": "^1.0.1",
+            "figgy-pudding": "^3.1.0",
+            "glob": "^7.1.2",
+            "graceful-fs": "^4.1.11",
+            "lru-cache": "^4.1.2",
+            "mississippi": "^3.0.0",
+            "mkdirp": "^0.5.1",
+            "move-concurrently": "^1.0.1",
+            "promise-inflight": "^1.0.1",
+            "rimraf": "^2.6.2",
+            "ssri": "^6.0.0",
+            "unique-filename": "^1.1.0",
+            "y18n": "^4.0.0"
           },
           "dependencies": {
             "y18n": {
@@ -3862,16 +5737,16 @@
           "version": "3.1.2",
           "bundled": true,
           "requires": {
-            "string-width": "2.1.1",
-            "strip-ansi": "3.0.1"
+            "string-width": "^2.0.0",
+            "strip-ansi": "^3.0.1"
           },
           "dependencies": {
             "string-width": {
               "version": "2.1.1",
               "bundled": true,
               "requires": {
-                "is-fullwidth-code-point": "2.0.0",
-                "strip-ansi": "4.0.0"
+                "is-fullwidth-code-point": "^2.0.0",
+                "strip-ansi": "^4.0.0"
               },
               "dependencies": {
                 "is-fullwidth-code-point": {
@@ -3882,7 +5757,7 @@
                   "version": "4.0.0",
                   "bundled": true,
                   "requires": {
-                    "ansi-regex": "3.0.0"
+                    "ansi-regex": "^3.0.0"
                   }
                 }
               }
@@ -3891,7 +5766,7 @@
               "version": "3.0.1",
               "bundled": true,
               "requires": {
-                "ansi-regex": "2.1.1"
+                "ansi-regex": "^2.0.0"
               },
               "dependencies": {
                 "ansi-regex": {
@@ -3906,9 +5781,9 @@
           "version": "0.2.0",
           "bundled": true,
           "requires": {
-            "colors": "1.1.2",
-            "lodash": "3.10.1",
-            "string-width": "1.0.2"
+            "colors": "^1.1.2",
+            "lodash": "^3.10.1",
+            "string-width": "^1.0.1"
           },
           "dependencies": {
             "colors": {
@@ -3924,9 +5799,9 @@
               "version": "1.0.2",
               "bundled": true,
               "requires": {
-                "code-point-at": "1.1.0",
-                "is-fullwidth-code-point": "1.0.0",
-                "strip-ansi": "3.0.1"
+                "code-point-at": "^1.0.0",
+                "is-fullwidth-code-point": "^1.0.0",
+                "strip-ansi": "^3.0.0"
               },
               "dependencies": {
                 "code-point-at": {
@@ -3937,7 +5812,7 @@
                   "version": "1.0.0",
                   "bundled": true,
                   "requires": {
-                    "number-is-nan": "1.0.1"
+                    "number-is-nan": "^1.0.0"
                   },
                   "dependencies": {
                     "number-is-nan": {
@@ -3950,7 +5825,7 @@
                   "version": "3.0.1",
                   "bundled": true,
                   "requires": {
-                    "ansi-regex": "2.1.1"
+                    "ansi-regex": "^2.0.0"
                   },
                   "dependencies": {
                     "ansi-regex": {
@@ -3967,23 +5842,23 @@
           "version": "2.0.2",
           "bundled": true,
           "requires": {
-            "graceful-fs": "4.1.11",
-            "mkdirp": "0.5.1"
+            "graceful-fs": "^4.1.2",
+            "mkdirp": "~0.5.0"
           }
         },
         "columnify": {
           "version": "1.5.4",
           "bundled": true,
           "requires": {
-            "strip-ansi": "3.0.1",
-            "wcwidth": "1.0.1"
+            "strip-ansi": "^3.0.0",
+            "wcwidth": "^1.0.0"
           },
           "dependencies": {
             "strip-ansi": {
               "version": "3.0.1",
               "bundled": true,
               "requires": {
-                "ansi-regex": "2.1.1"
+                "ansi-regex": "^2.0.0"
               },
               "dependencies": {
                 "ansi-regex": {
@@ -3996,14 +5871,14 @@
               "version": "1.0.1",
               "bundled": true,
               "requires": {
-                "defaults": "1.0.3"
+                "defaults": "^1.0.3"
               },
               "dependencies": {
                 "defaults": {
                   "version": "1.0.3",
                   "bundled": true,
                   "requires": {
-                    "clone": "1.0.2"
+                    "clone": "^1.0.2"
                   },
                   "dependencies": {
                     "clone": {
@@ -4020,8 +5895,8 @@
           "version": "1.1.11",
           "bundled": true,
           "requires": {
-            "ini": "1.3.5",
-            "proto-list": "1.2.4"
+            "ini": "^1.3.4",
+            "proto-list": "~1.2.1"
           },
           "dependencies": {
             "proto-list": {
@@ -4046,8 +5921,8 @@
           "version": "1.0.3",
           "bundled": true,
           "requires": {
-            "asap": "2.0.5",
-            "wrappy": "1.0.2"
+            "asap": "^2.0.0",
+            "wrappy": "1"
           },
           "dependencies": {
             "asap": {
@@ -4072,19 +5947,19 @@
           "version": "1.2.10",
           "bundled": true,
           "requires": {
-            "graceful-fs": "4.1.11",
-            "path-is-inside": "1.0.2",
-            "rimraf": "2.6.2"
+            "graceful-fs": "^4.1.2",
+            "path-is-inside": "^1.0.1",
+            "rimraf": "^2.5.2"
           }
         },
         "fs-write-stream-atomic": {
           "version": "1.0.10",
           "bundled": true,
           "requires": {
-            "graceful-fs": "4.1.11",
-            "iferr": "0.1.5",
-            "imurmurhash": "0.1.4",
-            "readable-stream": "2.3.6"
+            "graceful-fs": "^4.1.2",
+            "iferr": "^0.1.5",
+            "imurmurhash": "^0.1.4",
+            "readable-stream": "1 || 2"
           },
           "dependencies": {
             "iferr": {
@@ -4097,14 +5972,14 @@
           "version": "2.0.1",
           "bundled": true,
           "requires": {
-            "aproba": "1.2.0",
-            "fs-vacuum": "1.2.10",
-            "graceful-fs": "4.1.11",
-            "iferr": "0.1.5",
-            "mkdirp": "0.5.1",
-            "path-is-inside": "1.0.2",
-            "read-cmd-shim": "1.0.1",
-            "slide": "1.1.6"
+            "aproba": "^1.1.2",
+            "fs-vacuum": "^1.2.10",
+            "graceful-fs": "^4.1.11",
+            "iferr": "^0.1.5",
+            "mkdirp": "^0.5.1",
+            "path-is-inside": "^1.0.2",
+            "read-cmd-shim": "^1.0.1",
+            "slide": "^1.1.6"
           },
           "dependencies": {
             "iferr": {
@@ -4117,12 +5992,12 @@
           "version": "7.1.2",
           "bundled": true,
           "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           },
           "dependencies": {
             "fs.realpath": {
@@ -4133,14 +6008,14 @@
               "version": "3.0.4",
               "bundled": true,
               "requires": {
-                "brace-expansion": "1.1.8"
+                "brace-expansion": "^1.1.7"
               },
               "dependencies": {
                 "brace-expansion": {
                   "version": "1.1.8",
                   "bundled": true,
                   "requires": {
-                    "balanced-match": "1.0.0",
+                    "balanced-match": "^1.0.0",
                     "concat-map": "0.0.1"
                   },
                   "dependencies": {
@@ -4186,8 +6061,8 @@
           "version": "1.0.6",
           "bundled": true,
           "requires": {
-            "once": "1.4.0",
-            "wrappy": "1.0.2"
+            "once": "^1.3.0",
+            "wrappy": "1"
           }
         },
         "inherits": {
@@ -4202,21 +6077,21 @@
           "version": "1.10.3",
           "bundled": true,
           "requires": {
-            "glob": "7.1.2",
-            "npm-package-arg": "6.1.0",
-            "promzard": "0.3.0",
-            "read": "1.0.7",
-            "read-package-json": "2.0.13",
-            "semver": "5.5.0",
-            "validate-npm-package-license": "3.0.3",
-            "validate-npm-package-name": "3.0.0"
+            "glob": "^7.1.1",
+            "npm-package-arg": "^4.0.0 || ^5.0.0 || ^6.0.0",
+            "promzard": "^0.3.0",
+            "read": "~1.0.1",
+            "read-package-json": "1 || 2",
+            "semver": "2.x || 3.x || 4 || 5",
+            "validate-npm-package-license": "^3.0.1",
+            "validate-npm-package-name": "^3.0.0"
           },
           "dependencies": {
             "promzard": {
               "version": "0.3.0",
               "bundled": true,
               "requires": {
-                "read": "1.0.7"
+                "read": "1"
               }
             }
           }
@@ -4225,14 +6100,14 @@
           "version": "2.0.5",
           "bundled": true,
           "requires": {
-            "cidr-regex": "2.0.8"
+            "cidr-regex": "^2.0.8"
           },
           "dependencies": {
             "cidr-regex": {
               "version": "2.0.8",
               "bundled": true,
               "requires": {
-                "ip-regex": "2.1.0"
+                "ip-regex": "^2.1.0"
               },
               "dependencies": {
                 "ip-regex": {
@@ -4255,19 +6130,19 @@
           "version": "1.6.2",
           "bundled": true,
           "requires": {
-            "bin-links": "1.1.2",
-            "bluebird": "3.5.1",
-            "find-npm-prefix": "1.0.2",
-            "graceful-fs": "4.1.11",
-            "lock-verify": "2.0.2",
-            "npm-lifecycle": "2.0.1",
-            "npm-logical-tree": "1.2.1",
-            "npm-package-arg": "6.1.0",
-            "pacote": "7.6.1",
-            "protoduck": "5.0.0",
-            "read-package-json": "2.0.13",
-            "rimraf": "2.6.2",
-            "worker-farm": "1.6.0"
+            "bin-links": "^1.1.0",
+            "bluebird": "^3.5.1",
+            "find-npm-prefix": "^1.0.2",
+            "graceful-fs": "^4.1.11",
+            "lock-verify": "^2.0.0",
+            "npm-lifecycle": "^2.0.0",
+            "npm-logical-tree": "^1.2.1",
+            "npm-package-arg": "^6.0.0",
+            "pacote": "^7.5.1",
+            "protoduck": "^5.0.0",
+            "read-package-json": "^2.0.12",
+            "rimraf": "^2.6.2",
+            "worker-farm": "^1.5.4"
           },
           "dependencies": {
             "npm-logical-tree": {
@@ -4278,75 +6153,75 @@
               "version": "7.6.1",
               "bundled": true,
               "requires": {
-                "bluebird": "3.5.1",
-                "cacache": "10.0.4",
-                "get-stream": "3.0.0",
-                "glob": "7.1.2",
-                "lru-cache": "4.1.2",
-                "make-fetch-happen": "2.6.0",
-                "minimatch": "3.0.4",
-                "mississippi": "3.0.0",
-                "mkdirp": "0.5.1",
-                "normalize-package-data": "2.4.0",
-                "npm-package-arg": "6.1.0",
-                "npm-packlist": "1.1.10",
-                "npm-pick-manifest": "2.1.0",
-                "osenv": "0.1.5",
-                "promise-inflight": "1.0.1",
-                "promise-retry": "1.1.1",
-                "protoduck": "5.0.0",
-                "rimraf": "2.6.2",
-                "safe-buffer": "5.1.2",
-                "semver": "5.5.0",
-                "ssri": "5.3.0",
-                "tar": "4.4.2",
-                "unique-filename": "1.1.0",
-                "which": "1.3.0"
+                "bluebird": "^3.5.1",
+                "cacache": "^10.0.4",
+                "get-stream": "^3.0.0",
+                "glob": "^7.1.2",
+                "lru-cache": "^4.1.1",
+                "make-fetch-happen": "^2.6.0",
+                "minimatch": "^3.0.4",
+                "mississippi": "^3.0.0",
+                "mkdirp": "^0.5.1",
+                "normalize-package-data": "^2.4.0",
+                "npm-package-arg": "^6.0.0",
+                "npm-packlist": "^1.1.10",
+                "npm-pick-manifest": "^2.1.0",
+                "osenv": "^0.1.5",
+                "promise-inflight": "^1.0.1",
+                "promise-retry": "^1.1.1",
+                "protoduck": "^5.0.0",
+                "rimraf": "^2.6.2",
+                "safe-buffer": "^5.1.1",
+                "semver": "^5.5.0",
+                "ssri": "^5.2.4",
+                "tar": "^4.4.0",
+                "unique-filename": "^1.1.0",
+                "which": "^1.3.0"
               },
               "dependencies": {
                 "cacache": {
                   "version": "10.0.4",
                   "bundled": true,
                   "requires": {
-                    "bluebird": "3.5.1",
-                    "chownr": "1.0.1",
-                    "glob": "7.1.2",
-                    "graceful-fs": "4.1.11",
-                    "lru-cache": "4.1.2",
-                    "mississippi": "2.0.0",
-                    "mkdirp": "0.5.1",
-                    "move-concurrently": "1.0.1",
-                    "promise-inflight": "1.0.1",
-                    "rimraf": "2.6.2",
-                    "ssri": "5.3.0",
-                    "unique-filename": "1.1.0",
-                    "y18n": "4.0.0"
+                    "bluebird": "^3.5.1",
+                    "chownr": "^1.0.1",
+                    "glob": "^7.1.2",
+                    "graceful-fs": "^4.1.11",
+                    "lru-cache": "^4.1.1",
+                    "mississippi": "^2.0.0",
+                    "mkdirp": "^0.5.1",
+                    "move-concurrently": "^1.0.1",
+                    "promise-inflight": "^1.0.1",
+                    "rimraf": "^2.6.2",
+                    "ssri": "^5.2.4",
+                    "unique-filename": "^1.1.0",
+                    "y18n": "^4.0.0"
                   },
                   "dependencies": {
                     "mississippi": {
                       "version": "2.0.0",
                       "bundled": true,
                       "requires": {
-                        "concat-stream": "1.6.2",
-                        "duplexify": "3.5.4",
-                        "end-of-stream": "1.4.1",
-                        "flush-write-stream": "1.0.3",
-                        "from2": "2.3.0",
-                        "parallel-transform": "1.1.0",
-                        "pump": "2.0.1",
-                        "pumpify": "1.4.0",
-                        "stream-each": "1.2.2",
-                        "through2": "2.0.3"
+                        "concat-stream": "^1.5.0",
+                        "duplexify": "^3.4.2",
+                        "end-of-stream": "^1.1.0",
+                        "flush-write-stream": "^1.0.0",
+                        "from2": "^2.1.0",
+                        "parallel-transform": "^1.1.0",
+                        "pump": "^2.0.1",
+                        "pumpify": "^1.3.3",
+                        "stream-each": "^1.1.0",
+                        "through2": "^2.0.0"
                       },
                       "dependencies": {
                         "concat-stream": {
                           "version": "1.6.2",
                           "bundled": true,
                           "requires": {
-                            "buffer-from": "1.0.0",
-                            "inherits": "2.0.3",
-                            "readable-stream": "2.3.6",
-                            "typedarray": "0.0.6"
+                            "buffer-from": "^1.0.0",
+                            "inherits": "^2.0.3",
+                            "readable-stream": "^2.2.2",
+                            "typedarray": "^0.0.6"
                           },
                           "dependencies": {
                             "buffer-from": {
@@ -4363,10 +6238,10 @@
                           "version": "3.5.4",
                           "bundled": true,
                           "requires": {
-                            "end-of-stream": "1.4.1",
-                            "inherits": "2.0.3",
-                            "readable-stream": "2.3.6",
-                            "stream-shift": "1.0.0"
+                            "end-of-stream": "^1.0.0",
+                            "inherits": "^2.0.1",
+                            "readable-stream": "^2.0.0",
+                            "stream-shift": "^1.0.0"
                           },
                           "dependencies": {
                             "stream-shift": {
@@ -4379,32 +6254,32 @@
                           "version": "1.4.1",
                           "bundled": true,
                           "requires": {
-                            "once": "1.4.0"
+                            "once": "^1.4.0"
                           }
                         },
                         "flush-write-stream": {
                           "version": "1.0.3",
                           "bundled": true,
                           "requires": {
-                            "inherits": "2.0.3",
-                            "readable-stream": "2.3.6"
+                            "inherits": "^2.0.1",
+                            "readable-stream": "^2.0.4"
                           }
                         },
                         "from2": {
                           "version": "2.3.0",
                           "bundled": true,
                           "requires": {
-                            "inherits": "2.0.3",
-                            "readable-stream": "2.3.6"
+                            "inherits": "^2.0.1",
+                            "readable-stream": "^2.0.0"
                           }
                         },
                         "parallel-transform": {
                           "version": "1.1.0",
                           "bundled": true,
                           "requires": {
-                            "cyclist": "0.2.2",
-                            "inherits": "2.0.3",
-                            "readable-stream": "2.3.6"
+                            "cyclist": "~0.2.2",
+                            "inherits": "^2.0.3",
+                            "readable-stream": "^2.1.5"
                           },
                           "dependencies": {
                             "cyclist": {
@@ -4417,25 +6292,25 @@
                           "version": "2.0.1",
                           "bundled": true,
                           "requires": {
-                            "end-of-stream": "1.4.1",
-                            "once": "1.4.0"
+                            "end-of-stream": "^1.1.0",
+                            "once": "^1.3.1"
                           }
                         },
                         "pumpify": {
                           "version": "1.4.0",
                           "bundled": true,
                           "requires": {
-                            "duplexify": "3.5.4",
-                            "inherits": "2.0.3",
-                            "pump": "2.0.1"
+                            "duplexify": "^3.5.3",
+                            "inherits": "^2.0.3",
+                            "pump": "^2.0.0"
                           }
                         },
                         "stream-each": {
                           "version": "1.2.2",
                           "bundled": true,
                           "requires": {
-                            "end-of-stream": "1.4.1",
-                            "stream-shift": "1.0.0"
+                            "end-of-stream": "^1.1.0",
+                            "stream-shift": "^1.0.0"
                           },
                           "dependencies": {
                             "stream-shift": {
@@ -4448,8 +6323,8 @@
                           "version": "2.0.3",
                           "bundled": true,
                           "requires": {
-                            "readable-stream": "2.3.6",
-                            "xtend": "4.0.1"
+                            "readable-stream": "^2.1.5",
+                            "xtend": "~4.0.1"
                           },
                           "dependencies": {
                             "xtend": {
@@ -4474,31 +6349,31 @@
                   "version": "2.6.0",
                   "bundled": true,
                   "requires": {
-                    "agentkeepalive": "3.4.1",
-                    "cacache": "10.0.4",
-                    "http-cache-semantics": "3.8.1",
-                    "http-proxy-agent": "2.1.0",
-                    "https-proxy-agent": "2.2.1",
-                    "lru-cache": "4.1.2",
-                    "mississippi": "1.3.1",
-                    "node-fetch-npm": "2.0.2",
-                    "promise-retry": "1.1.1",
-                    "socks-proxy-agent": "3.0.1",
-                    "ssri": "5.3.0"
+                    "agentkeepalive": "^3.3.0",
+                    "cacache": "^10.0.0",
+                    "http-cache-semantics": "^3.8.0",
+                    "http-proxy-agent": "^2.0.0",
+                    "https-proxy-agent": "^2.1.0",
+                    "lru-cache": "^4.1.1",
+                    "mississippi": "^1.2.0",
+                    "node-fetch-npm": "^2.0.2",
+                    "promise-retry": "^1.1.1",
+                    "socks-proxy-agent": "^3.0.1",
+                    "ssri": "^5.0.0"
                   },
                   "dependencies": {
                     "agentkeepalive": {
                       "version": "3.4.1",
                       "bundled": true,
                       "requires": {
-                        "humanize-ms": "1.2.1"
+                        "humanize-ms": "^1.2.1"
                       },
                       "dependencies": {
                         "humanize-ms": {
                           "version": "1.2.1",
                           "bundled": true,
                           "requires": {
-                            "ms": "2.1.1"
+                            "ms": "^2.0.0"
                           },
                           "dependencies": {
                             "ms": {
@@ -4517,7 +6392,7 @@
                       "version": "2.1.0",
                       "bundled": true,
                       "requires": {
-                        "agent-base": "4.2.0",
+                        "agent-base": "4",
                         "debug": "3.1.0"
                       },
                       "dependencies": {
@@ -4525,14 +6400,14 @@
                           "version": "4.2.0",
                           "bundled": true,
                           "requires": {
-                            "es6-promisify": "5.0.0"
+                            "es6-promisify": "^5.0.0"
                           },
                           "dependencies": {
                             "es6-promisify": {
                               "version": "5.0.0",
                               "bundled": true,
                               "requires": {
-                                "es6-promise": "4.2.4"
+                                "es6-promise": "^4.0.3"
                               },
                               "dependencies": {
                                 "es6-promise": {
@@ -4562,22 +6437,22 @@
                       "version": "2.2.1",
                       "bundled": true,
                       "requires": {
-                        "agent-base": "4.2.0",
-                        "debug": "3.1.0"
+                        "agent-base": "^4.1.0",
+                        "debug": "^3.1.0"
                       },
                       "dependencies": {
                         "agent-base": {
                           "version": "4.2.0",
                           "bundled": true,
                           "requires": {
-                            "es6-promisify": "5.0.0"
+                            "es6-promisify": "^5.0.0"
                           },
                           "dependencies": {
                             "es6-promisify": {
                               "version": "5.0.0",
                               "bundled": true,
                               "requires": {
-                                "es6-promise": "4.2.4"
+                                "es6-promise": "^4.0.3"
                               },
                               "dependencies": {
                                 "es6-promise": {
@@ -4607,26 +6482,26 @@
                       "version": "1.3.1",
                       "bundled": true,
                       "requires": {
-                        "concat-stream": "1.6.2",
-                        "duplexify": "3.5.4",
-                        "end-of-stream": "1.4.1",
-                        "flush-write-stream": "1.0.3",
-                        "from2": "2.3.0",
-                        "parallel-transform": "1.1.0",
-                        "pump": "1.0.3",
-                        "pumpify": "1.4.0",
-                        "stream-each": "1.2.2",
-                        "through2": "2.0.3"
+                        "concat-stream": "^1.5.0",
+                        "duplexify": "^3.4.2",
+                        "end-of-stream": "^1.1.0",
+                        "flush-write-stream": "^1.0.0",
+                        "from2": "^2.1.0",
+                        "parallel-transform": "^1.1.0",
+                        "pump": "^1.0.0",
+                        "pumpify": "^1.3.3",
+                        "stream-each": "^1.1.0",
+                        "through2": "^2.0.0"
                       },
                       "dependencies": {
                         "concat-stream": {
                           "version": "1.6.2",
                           "bundled": true,
                           "requires": {
-                            "buffer-from": "1.0.0",
-                            "inherits": "2.0.3",
-                            "readable-stream": "2.3.6",
-                            "typedarray": "0.0.6"
+                            "buffer-from": "^1.0.0",
+                            "inherits": "^2.0.3",
+                            "readable-stream": "^2.2.2",
+                            "typedarray": "^0.0.6"
                           },
                           "dependencies": {
                             "buffer-from": {
@@ -4643,10 +6518,10 @@
                           "version": "3.5.4",
                           "bundled": true,
                           "requires": {
-                            "end-of-stream": "1.4.1",
-                            "inherits": "2.0.3",
-                            "readable-stream": "2.3.6",
-                            "stream-shift": "1.0.0"
+                            "end-of-stream": "^1.0.0",
+                            "inherits": "^2.0.1",
+                            "readable-stream": "^2.0.0",
+                            "stream-shift": "^1.0.0"
                           },
                           "dependencies": {
                             "stream-shift": {
@@ -4659,32 +6534,32 @@
                           "version": "1.4.1",
                           "bundled": true,
                           "requires": {
-                            "once": "1.4.0"
+                            "once": "^1.4.0"
                           }
                         },
                         "flush-write-stream": {
                           "version": "1.0.3",
                           "bundled": true,
                           "requires": {
-                            "inherits": "2.0.3",
-                            "readable-stream": "2.3.6"
+                            "inherits": "^2.0.1",
+                            "readable-stream": "^2.0.4"
                           }
                         },
                         "from2": {
                           "version": "2.3.0",
                           "bundled": true,
                           "requires": {
-                            "inherits": "2.0.3",
-                            "readable-stream": "2.3.6"
+                            "inherits": "^2.0.1",
+                            "readable-stream": "^2.0.0"
                           }
                         },
                         "parallel-transform": {
                           "version": "1.1.0",
                           "bundled": true,
                           "requires": {
-                            "cyclist": "0.2.2",
-                            "inherits": "2.0.3",
-                            "readable-stream": "2.3.6"
+                            "cyclist": "~0.2.2",
+                            "inherits": "^2.0.3",
+                            "readable-stream": "^2.1.5"
                           },
                           "dependencies": {
                             "cyclist": {
@@ -4697,25 +6572,25 @@
                           "version": "1.0.3",
                           "bundled": true,
                           "requires": {
-                            "end-of-stream": "1.4.1",
-                            "once": "1.4.0"
+                            "end-of-stream": "^1.1.0",
+                            "once": "^1.3.1"
                           }
                         },
                         "pumpify": {
                           "version": "1.4.0",
                           "bundled": true,
                           "requires": {
-                            "duplexify": "3.5.4",
-                            "inherits": "2.0.3",
-                            "pump": "2.0.1"
+                            "duplexify": "^3.5.3",
+                            "inherits": "^2.0.3",
+                            "pump": "^2.0.0"
                           },
                           "dependencies": {
                             "pump": {
                               "version": "2.0.1",
                               "bundled": true,
                               "requires": {
-                                "end-of-stream": "1.4.1",
-                                "once": "1.4.0"
+                                "end-of-stream": "^1.1.0",
+                                "once": "^1.3.1"
                               }
                             }
                           }
@@ -4724,8 +6599,8 @@
                           "version": "1.2.2",
                           "bundled": true,
                           "requires": {
-                            "end-of-stream": "1.4.1",
-                            "stream-shift": "1.0.0"
+                            "end-of-stream": "^1.1.0",
+                            "stream-shift": "^1.0.0"
                           },
                           "dependencies": {
                             "stream-shift": {
@@ -4738,8 +6613,8 @@
                           "version": "2.0.3",
                           "bundled": true,
                           "requires": {
-                            "readable-stream": "2.3.6",
-                            "xtend": "4.0.1"
+                            "readable-stream": "^2.1.5",
+                            "xtend": "~4.0.1"
                           },
                           "dependencies": {
                             "xtend": {
@@ -4754,23 +6629,23 @@
                       "version": "2.0.2",
                       "bundled": true,
                       "requires": {
-                        "encoding": "0.1.12",
-                        "json-parse-better-errors": "1.0.2",
-                        "safe-buffer": "5.1.2"
+                        "encoding": "^0.1.11",
+                        "json-parse-better-errors": "^1.0.0",
+                        "safe-buffer": "^5.1.1"
                       },
                       "dependencies": {
                         "encoding": {
                           "version": "0.1.12",
                           "bundled": true,
                           "requires": {
-                            "iconv-lite": "0.4.21"
+                            "iconv-lite": "~0.4.13"
                           },
                           "dependencies": {
                             "iconv-lite": {
                               "version": "0.4.21",
                               "bundled": true,
                               "requires": {
-                                "safer-buffer": "2.1.2"
+                                "safer-buffer": "^2.1.0"
                               },
                               "dependencies": {
                                 "safer-buffer": {
@@ -4787,22 +6662,22 @@
                       "version": "3.0.1",
                       "bundled": true,
                       "requires": {
-                        "agent-base": "4.2.0",
-                        "socks": "1.1.10"
+                        "agent-base": "^4.1.0",
+                        "socks": "^1.1.10"
                       },
                       "dependencies": {
                         "agent-base": {
                           "version": "4.2.0",
                           "bundled": true,
                           "requires": {
-                            "es6-promisify": "5.0.0"
+                            "es6-promisify": "^5.0.0"
                           },
                           "dependencies": {
                             "es6-promisify": {
                               "version": "5.0.0",
                               "bundled": true,
                               "requires": {
-                                "es6-promise": "4.2.4"
+                                "es6-promise": "^4.0.3"
                               },
                               "dependencies": {
                                 "es6-promise": {
@@ -4817,8 +6692,8 @@
                           "version": "1.1.10",
                           "bundled": true,
                           "requires": {
-                            "ip": "1.1.5",
-                            "smart-buffer": "1.1.15"
+                            "ip": "^1.1.4",
+                            "smart-buffer": "^1.0.13"
                           },
                           "dependencies": {
                             "ip": {
@@ -4839,14 +6714,14 @@
                   "version": "3.0.4",
                   "bundled": true,
                   "requires": {
-                    "brace-expansion": "1.1.11"
+                    "brace-expansion": "^1.1.7"
                   },
                   "dependencies": {
                     "brace-expansion": {
                       "version": "1.1.11",
                       "bundled": true,
                       "requires": {
-                        "balanced-match": "1.0.0",
+                        "balanced-match": "^1.0.0",
                         "concat-map": "0.0.1"
                       },
                       "dependencies": {
@@ -4866,8 +6741,8 @@
                   "version": "1.1.1",
                   "bundled": true,
                   "requires": {
-                    "err-code": "1.1.2",
-                    "retry": "0.10.1"
+                    "err-code": "^1.0.0",
+                    "retry": "^0.10.0"
                   },
                   "dependencies": {
                     "err-code": {
@@ -4884,7 +6759,7 @@
                   "version": "5.3.0",
                   "bundled": true,
                   "requires": {
-                    "safe-buffer": "5.1.2"
+                    "safe-buffer": "^5.1.1"
                   }
                 }
               }
@@ -4893,7 +6768,7 @@
               "version": "5.0.0",
               "bundled": true,
               "requires": {
-                "genfun": "4.0.1"
+                "genfun": "^4.0.1"
               },
               "dependencies": {
                 "genfun": {
@@ -4908,50 +6783,50 @@
           "version": "4.0.1",
           "bundled": true,
           "requires": {
-            "figgy-pudding": "3.1.0",
-            "npm-registry-fetch": "3.1.1"
+            "figgy-pudding": "^3.1.0",
+            "npm-registry-fetch": "^3.0.0"
           },
           "dependencies": {
             "npm-registry-fetch": {
               "version": "3.1.1",
               "bundled": true,
               "requires": {
-                "bluebird": "3.5.1",
-                "figgy-pudding": "3.1.0",
-                "lru-cache": "4.1.2",
-                "make-fetch-happen": "4.0.1",
-                "npm-package-arg": "6.1.0"
+                "bluebird": "^3.5.1",
+                "figgy-pudding": "^3.1.0",
+                "lru-cache": "^4.1.2",
+                "make-fetch-happen": "^4.0.0",
+                "npm-package-arg": "^6.0.0"
               },
               "dependencies": {
                 "make-fetch-happen": {
                   "version": "4.0.1",
                   "bundled": true,
                   "requires": {
-                    "agentkeepalive": "3.4.1",
-                    "cacache": "11.0.1",
-                    "http-cache-semantics": "3.8.1",
-                    "http-proxy-agent": "2.1.0",
-                    "https-proxy-agent": "2.2.1",
-                    "lru-cache": "4.1.2",
-                    "mississippi": "3.0.0",
-                    "node-fetch-npm": "2.0.2",
-                    "promise-retry": "1.1.1",
-                    "socks-proxy-agent": "4.0.0",
-                    "ssri": "6.0.0"
+                    "agentkeepalive": "^3.4.1",
+                    "cacache": "^11.0.1",
+                    "http-cache-semantics": "^3.8.1",
+                    "http-proxy-agent": "^2.1.0",
+                    "https-proxy-agent": "^2.2.1",
+                    "lru-cache": "^4.1.2",
+                    "mississippi": "^3.0.0",
+                    "node-fetch-npm": "^2.0.2",
+                    "promise-retry": "^1.1.1",
+                    "socks-proxy-agent": "^4.0.0",
+                    "ssri": "^6.0.0"
                   },
                   "dependencies": {
                     "agentkeepalive": {
                       "version": "3.4.1",
                       "bundled": true,
                       "requires": {
-                        "humanize-ms": "1.2.1"
+                        "humanize-ms": "^1.2.1"
                       },
                       "dependencies": {
                         "humanize-ms": {
                           "version": "1.2.1",
                           "bundled": true,
                           "requires": {
-                            "ms": "2.1.1"
+                            "ms": "^2.0.0"
                           },
                           "dependencies": {
                             "ms": {
@@ -4970,7 +6845,7 @@
                       "version": "2.1.0",
                       "bundled": true,
                       "requires": {
-                        "agent-base": "4.2.0",
+                        "agent-base": "4",
                         "debug": "3.1.0"
                       },
                       "dependencies": {
@@ -4978,14 +6853,14 @@
                           "version": "4.2.0",
                           "bundled": true,
                           "requires": {
-                            "es6-promisify": "5.0.0"
+                            "es6-promisify": "^5.0.0"
                           },
                           "dependencies": {
                             "es6-promisify": {
                               "version": "5.0.0",
                               "bundled": true,
                               "requires": {
-                                "es6-promise": "4.2.4"
+                                "es6-promise": "^4.0.3"
                               },
                               "dependencies": {
                                 "es6-promise": {
@@ -5015,22 +6890,22 @@
                       "version": "2.2.1",
                       "bundled": true,
                       "requires": {
-                        "agent-base": "4.2.0",
-                        "debug": "3.1.0"
+                        "agent-base": "^4.1.0",
+                        "debug": "^3.1.0"
                       },
                       "dependencies": {
                         "agent-base": {
                           "version": "4.2.0",
                           "bundled": true,
                           "requires": {
-                            "es6-promisify": "5.0.0"
+                            "es6-promisify": "^5.0.0"
                           },
                           "dependencies": {
                             "es6-promisify": {
                               "version": "5.0.0",
                               "bundled": true,
                               "requires": {
-                                "es6-promise": "4.2.4"
+                                "es6-promise": "^4.0.3"
                               },
                               "dependencies": {
                                 "es6-promise": {
@@ -5060,23 +6935,23 @@
                       "version": "2.0.2",
                       "bundled": true,
                       "requires": {
-                        "encoding": "0.1.12",
-                        "json-parse-better-errors": "1.0.2",
-                        "safe-buffer": "5.1.2"
+                        "encoding": "^0.1.11",
+                        "json-parse-better-errors": "^1.0.0",
+                        "safe-buffer": "^5.1.1"
                       },
                       "dependencies": {
                         "encoding": {
                           "version": "0.1.12",
                           "bundled": true,
                           "requires": {
-                            "iconv-lite": "0.4.21"
+                            "iconv-lite": "~0.4.13"
                           },
                           "dependencies": {
                             "iconv-lite": {
                               "version": "0.4.21",
                               "bundled": true,
                               "requires": {
-                                "safer-buffer": "2.1.2"
+                                "safer-buffer": "^2.1.0"
                               },
                               "dependencies": {
                                 "safer-buffer": {
@@ -5093,8 +6968,8 @@
                       "version": "1.1.1",
                       "bundled": true,
                       "requires": {
-                        "err-code": "1.1.2",
-                        "retry": "0.10.1"
+                        "err-code": "^1.0.0",
+                        "retry": "^0.10.0"
                       },
                       "dependencies": {
                         "err-code": {
@@ -5111,22 +6986,22 @@
                       "version": "4.0.0",
                       "bundled": true,
                       "requires": {
-                        "agent-base": "4.1.2",
-                        "socks": "2.1.6"
+                        "agent-base": "~4.1.0",
+                        "socks": "~2.1.6"
                       },
                       "dependencies": {
                         "agent-base": {
                           "version": "4.1.2",
                           "bundled": true,
                           "requires": {
-                            "es6-promisify": "5.0.0"
+                            "es6-promisify": "^5.0.0"
                           },
                           "dependencies": {
                             "es6-promisify": {
                               "version": "5.0.0",
                               "bundled": true,
                               "requires": {
-                                "es6-promise": "4.2.4"
+                                "es6-promise": "^4.0.3"
                               },
                               "dependencies": {
                                 "es6-promise": {
@@ -5141,8 +7016,8 @@
                           "version": "2.1.6",
                           "bundled": true,
                           "requires": {
-                            "ip": "1.1.5",
-                            "smart-buffer": "4.0.1"
+                            "ip": "^1.1.5",
+                            "smart-buffer": "^4.0.1"
                           },
                           "dependencies": {
                             "ip": {
@@ -5167,14 +7042,14 @@
           "version": "10.2.0",
           "bundled": true,
           "requires": {
-            "dotenv": "5.0.1",
-            "npm-package-arg": "6.1.0",
-            "rimraf": "2.6.2",
-            "safe-buffer": "5.1.2",
-            "update-notifier": "2.5.0",
-            "which": "1.3.0",
-            "y18n": "4.0.0",
-            "yargs": "11.0.0"
+            "dotenv": "^5.0.1",
+            "npm-package-arg": "^6.0.0",
+            "rimraf": "^2.6.2",
+            "safe-buffer": "^5.1.0",
+            "update-notifier": "^2.3.0",
+            "which": "^1.3.0",
+            "y18n": "^4.0.0",
+            "yargs": "^11.0.0"
           },
           "dependencies": {
             "dotenv": {
@@ -5189,44 +7064,44 @@
               "version": "11.0.0",
               "bundled": true,
               "requires": {
-                "cliui": "4.0.0",
-                "decamelize": "1.2.0",
-                "find-up": "2.1.0",
-                "get-caller-file": "1.0.2",
-                "os-locale": "2.1.0",
-                "require-directory": "2.1.1",
-                "require-main-filename": "1.0.1",
-                "set-blocking": "2.0.0",
-                "string-width": "2.1.1",
-                "which-module": "2.0.0",
-                "y18n": "3.2.1",
-                "yargs-parser": "9.0.2"
+                "cliui": "^4.0.0",
+                "decamelize": "^1.1.1",
+                "find-up": "^2.1.0",
+                "get-caller-file": "^1.0.1",
+                "os-locale": "^2.0.0",
+                "require-directory": "^2.1.1",
+                "require-main-filename": "^1.0.1",
+                "set-blocking": "^2.0.0",
+                "string-width": "^2.0.0",
+                "which-module": "^2.0.0",
+                "y18n": "^3.2.1",
+                "yargs-parser": "^9.0.2"
               },
               "dependencies": {
                 "cliui": {
                   "version": "4.0.0",
                   "bundled": true,
                   "requires": {
-                    "string-width": "2.1.1",
-                    "strip-ansi": "4.0.0",
-                    "wrap-ansi": "2.1.0"
+                    "string-width": "^2.1.1",
+                    "strip-ansi": "^4.0.0",
+                    "wrap-ansi": "^2.0.0"
                   },
                   "dependencies": {
                     "wrap-ansi": {
                       "version": "2.1.0",
                       "bundled": true,
                       "requires": {
-                        "string-width": "1.0.2",
-                        "strip-ansi": "3.0.1"
+                        "string-width": "^1.0.1",
+                        "strip-ansi": "^3.0.1"
                       },
                       "dependencies": {
                         "string-width": {
                           "version": "1.0.2",
                           "bundled": true,
                           "requires": {
-                            "code-point-at": "1.1.0",
-                            "is-fullwidth-code-point": "1.0.0",
-                            "strip-ansi": "3.0.1"
+                            "code-point-at": "^1.0.0",
+                            "is-fullwidth-code-point": "^1.0.0",
+                            "strip-ansi": "^3.0.0"
                           },
                           "dependencies": {
                             "code-point-at": {
@@ -5237,7 +7112,7 @@
                               "version": "1.0.0",
                               "bundled": true,
                               "requires": {
-                                "number-is-nan": "1.0.1"
+                                "number-is-nan": "^1.0.0"
                               },
                               "dependencies": {
                                 "number-is-nan": {
@@ -5252,7 +7127,7 @@
                           "version": "3.0.1",
                           "bundled": true,
                           "requires": {
-                            "ansi-regex": "2.1.1"
+                            "ansi-regex": "^2.0.0"
                           },
                           "dependencies": {
                             "ansi-regex": {
@@ -5273,29 +7148,29 @@
                   "version": "2.1.0",
                   "bundled": true,
                   "requires": {
-                    "locate-path": "2.0.0"
+                    "locate-path": "^2.0.0"
                   },
                   "dependencies": {
                     "locate-path": {
                       "version": "2.0.0",
                       "bundled": true,
                       "requires": {
-                        "p-locate": "2.0.0",
-                        "path-exists": "3.0.0"
+                        "p-locate": "^2.0.0",
+                        "path-exists": "^3.0.0"
                       },
                       "dependencies": {
                         "p-locate": {
                           "version": "2.0.0",
                           "bundled": true,
                           "requires": {
-                            "p-limit": "1.2.0"
+                            "p-limit": "^1.1.0"
                           },
                           "dependencies": {
                             "p-limit": {
                               "version": "1.2.0",
                               "bundled": true,
                               "requires": {
-                                "p-try": "1.0.0"
+                                "p-try": "^1.0.0"
                               },
                               "dependencies": {
                                 "p-try": {
@@ -5322,38 +7197,38 @@
                   "version": "2.1.0",
                   "bundled": true,
                   "requires": {
-                    "execa": "0.7.0",
-                    "lcid": "1.0.0",
-                    "mem": "1.1.0"
+                    "execa": "^0.7.0",
+                    "lcid": "^1.0.0",
+                    "mem": "^1.1.0"
                   },
                   "dependencies": {
                     "execa": {
                       "version": "0.7.0",
                       "bundled": true,
                       "requires": {
-                        "cross-spawn": "5.1.0",
-                        "get-stream": "3.0.0",
-                        "is-stream": "1.1.0",
-                        "npm-run-path": "2.0.2",
-                        "p-finally": "1.0.0",
-                        "signal-exit": "3.0.2",
-                        "strip-eof": "1.0.0"
+                        "cross-spawn": "^5.0.1",
+                        "get-stream": "^3.0.0",
+                        "is-stream": "^1.1.0",
+                        "npm-run-path": "^2.0.0",
+                        "p-finally": "^1.0.0",
+                        "signal-exit": "^3.0.0",
+                        "strip-eof": "^1.0.0"
                       },
                       "dependencies": {
                         "cross-spawn": {
                           "version": "5.1.0",
                           "bundled": true,
                           "requires": {
-                            "lru-cache": "4.1.2",
-                            "shebang-command": "1.2.0",
-                            "which": "1.3.0"
+                            "lru-cache": "^4.0.1",
+                            "shebang-command": "^1.2.0",
+                            "which": "^1.2.9"
                           },
                           "dependencies": {
                             "shebang-command": {
                               "version": "1.2.0",
                               "bundled": true,
                               "requires": {
-                                "shebang-regex": "1.0.0"
+                                "shebang-regex": "^1.0.0"
                               },
                               "dependencies": {
                                 "shebang-regex": {
@@ -5376,7 +7251,7 @@
                           "version": "2.0.2",
                           "bundled": true,
                           "requires": {
-                            "path-key": "2.0.1"
+                            "path-key": "^2.0.0"
                           },
                           "dependencies": {
                             "path-key": {
@@ -5403,7 +7278,7 @@
                       "version": "1.0.0",
                       "bundled": true,
                       "requires": {
-                        "invert-kv": "1.0.0"
+                        "invert-kv": "^1.0.0"
                       },
                       "dependencies": {
                         "invert-kv": {
@@ -5416,7 +7291,7 @@
                       "version": "1.1.0",
                       "bundled": true,
                       "requires": {
-                        "mimic-fn": "1.2.0"
+                        "mimic-fn": "^1.0.0"
                       },
                       "dependencies": {
                         "mimic-fn": {
@@ -5443,8 +7318,8 @@
                   "version": "2.1.1",
                   "bundled": true,
                   "requires": {
-                    "is-fullwidth-code-point": "2.0.0",
-                    "strip-ansi": "4.0.0"
+                    "is-fullwidth-code-point": "^2.0.0",
+                    "strip-ansi": "^4.0.0"
                   },
                   "dependencies": {
                     "is-fullwidth-code-point": {
@@ -5465,7 +7340,7 @@
                   "version": "9.0.2",
                   "bundled": true,
                   "requires": {
-                    "camelcase": "4.1.0"
+                    "camelcase": "^4.1.0"
                   },
                   "dependencies": {
                     "camelcase": {
@@ -5482,15 +7357,15 @@
           "version": "2.0.2",
           "bundled": true,
           "requires": {
-            "npm-package-arg": "6.1.0",
-            "semver": "5.5.0"
+            "npm-package-arg": "^5.1.2 || 6",
+            "semver": "^5.4.1"
           }
         },
         "lockfile": {
           "version": "1.0.4",
           "bundled": true,
           "requires": {
-            "signal-exit": "3.0.2"
+            "signal-exit": "^3.0.2"
           },
           "dependencies": {
             "signal-exit": {
@@ -5507,8 +7382,8 @@
           "version": "4.6.0",
           "bundled": true,
           "requires": {
-            "lodash._createset": "4.0.3",
-            "lodash._root": "3.0.1"
+            "lodash._createset": "~4.0.0",
+            "lodash._root": "~3.0.0"
           },
           "dependencies": {
             "lodash._createset": {
@@ -5533,7 +7408,7 @@
           "version": "3.1.2",
           "bundled": true,
           "requires": {
-            "lodash._getnative": "3.9.1"
+            "lodash._getnative": "^3.0.0"
           }
         },
         "lodash._getnative": {
@@ -5564,8 +7439,8 @@
           "version": "4.1.2",
           "bundled": true,
           "requires": {
-            "pseudomap": "1.0.2",
-            "yallist": "2.1.2"
+            "pseudomap": "^1.0.2",
+            "yallist": "^2.1.2"
           },
           "dependencies": {
             "pseudomap": {
@@ -5586,25 +7461,25 @@
           "version": "3.0.0",
           "bundled": true,
           "requires": {
-            "concat-stream": "1.6.1",
-            "duplexify": "3.5.4",
-            "end-of-stream": "1.4.1",
-            "flush-write-stream": "1.0.2",
-            "from2": "2.3.0",
-            "parallel-transform": "1.1.0",
-            "pump": "3.0.0",
-            "pumpify": "1.4.0",
-            "stream-each": "1.2.2",
-            "through2": "2.0.3"
+            "concat-stream": "^1.5.0",
+            "duplexify": "^3.4.2",
+            "end-of-stream": "^1.1.0",
+            "flush-write-stream": "^1.0.0",
+            "from2": "^2.1.0",
+            "parallel-transform": "^1.1.0",
+            "pump": "^3.0.0",
+            "pumpify": "^1.3.3",
+            "stream-each": "^1.1.0",
+            "through2": "^2.0.0"
           },
           "dependencies": {
             "concat-stream": {
               "version": "1.6.1",
               "bundled": true,
               "requires": {
-                "inherits": "2.0.3",
-                "readable-stream": "2.3.6",
-                "typedarray": "0.0.6"
+                "inherits": "^2.0.3",
+                "readable-stream": "^2.2.2",
+                "typedarray": "^0.0.6"
               },
               "dependencies": {
                 "typedarray": {
@@ -5617,10 +7492,10 @@
               "version": "3.5.4",
               "bundled": true,
               "requires": {
-                "end-of-stream": "1.4.1",
-                "inherits": "2.0.3",
-                "readable-stream": "2.3.6",
-                "stream-shift": "1.0.0"
+                "end-of-stream": "^1.0.0",
+                "inherits": "^2.0.1",
+                "readable-stream": "^2.0.0",
+                "stream-shift": "^1.0.0"
               },
               "dependencies": {
                 "stream-shift": {
@@ -5633,32 +7508,32 @@
               "version": "1.4.1",
               "bundled": true,
               "requires": {
-                "once": "1.4.0"
+                "once": "^1.4.0"
               }
             },
             "flush-write-stream": {
               "version": "1.0.2",
               "bundled": true,
               "requires": {
-                "inherits": "2.0.3",
-                "readable-stream": "2.3.6"
+                "inherits": "^2.0.1",
+                "readable-stream": "^2.0.4"
               }
             },
             "from2": {
               "version": "2.3.0",
               "bundled": true,
               "requires": {
-                "inherits": "2.0.3",
-                "readable-stream": "2.3.6"
+                "inherits": "^2.0.1",
+                "readable-stream": "^2.0.0"
               }
             },
             "parallel-transform": {
               "version": "1.1.0",
               "bundled": true,
               "requires": {
-                "cyclist": "0.2.2",
-                "inherits": "2.0.3",
-                "readable-stream": "2.3.6"
+                "cyclist": "~0.2.2",
+                "inherits": "^2.0.3",
+                "readable-stream": "^2.1.5"
               },
               "dependencies": {
                 "cyclist": {
@@ -5671,25 +7546,25 @@
               "version": "3.0.0",
               "bundled": true,
               "requires": {
-                "end-of-stream": "1.4.1",
-                "once": "1.4.0"
+                "end-of-stream": "^1.1.0",
+                "once": "^1.3.1"
               }
             },
             "pumpify": {
               "version": "1.4.0",
               "bundled": true,
               "requires": {
-                "duplexify": "3.5.4",
-                "inherits": "2.0.3",
-                "pump": "2.0.1"
+                "duplexify": "^3.5.3",
+                "inherits": "^2.0.3",
+                "pump": "^2.0.0"
               },
               "dependencies": {
                 "pump": {
                   "version": "2.0.1",
                   "bundled": true,
                   "requires": {
-                    "end-of-stream": "1.4.1",
-                    "once": "1.4.0"
+                    "end-of-stream": "^1.1.0",
+                    "once": "^1.3.1"
                   }
                 }
               }
@@ -5698,8 +7573,8 @@
               "version": "1.2.2",
               "bundled": true,
               "requires": {
-                "end-of-stream": "1.4.1",
-                "stream-shift": "1.0.0"
+                "end-of-stream": "^1.1.0",
+                "stream-shift": "^1.0.0"
               },
               "dependencies": {
                 "stream-shift": {
@@ -5712,8 +7587,8 @@
               "version": "2.0.3",
               "bundled": true,
               "requires": {
-                "readable-stream": "2.3.6",
-                "xtend": "4.0.1"
+                "readable-stream": "^2.1.5",
+                "xtend": "~4.0.1"
               },
               "dependencies": {
                 "xtend": {
@@ -5741,24 +7616,24 @@
           "version": "1.0.1",
           "bundled": true,
           "requires": {
-            "aproba": "1.2.0",
-            "copy-concurrently": "1.0.5",
-            "fs-write-stream-atomic": "1.0.10",
-            "mkdirp": "0.5.1",
-            "rimraf": "2.6.2",
-            "run-queue": "1.0.3"
+            "aproba": "^1.1.1",
+            "copy-concurrently": "^1.0.0",
+            "fs-write-stream-atomic": "^1.0.8",
+            "mkdirp": "^0.5.1",
+            "rimraf": "^2.5.4",
+            "run-queue": "^1.0.3"
           },
           "dependencies": {
             "copy-concurrently": {
               "version": "1.0.5",
               "bundled": true,
               "requires": {
-                "aproba": "1.2.0",
-                "fs-write-stream-atomic": "1.0.10",
-                "iferr": "0.1.5",
-                "mkdirp": "0.5.1",
-                "rimraf": "2.6.2",
-                "run-queue": "1.0.3"
+                "aproba": "^1.1.1",
+                "fs-write-stream-atomic": "^1.0.8",
+                "iferr": "^0.1.5",
+                "mkdirp": "^0.5.1",
+                "rimraf": "^2.5.4",
+                "run-queue": "^1.0.0"
               },
               "dependencies": {
                 "iferr": {
@@ -5771,7 +7646,7 @@
               "version": "1.0.3",
               "bundled": true,
               "requires": {
-                "aproba": "1.2.0"
+                "aproba": "^1.1.1"
               }
             }
           }
@@ -5780,43 +7655,43 @@
           "version": "3.6.2",
           "bundled": true,
           "requires": {
-            "fstream": "1.0.11",
-            "glob": "7.1.2",
-            "graceful-fs": "4.1.11",
-            "minimatch": "3.0.4",
-            "mkdirp": "0.5.1",
-            "nopt": "3.0.6",
-            "npmlog": "4.1.2",
-            "osenv": "0.1.5",
-            "request": "2.85.0",
-            "rimraf": "2.6.2",
-            "semver": "5.3.0",
-            "tar": "2.2.1",
-            "which": "1.3.0"
+            "fstream": "^1.0.0",
+            "glob": "^7.0.3",
+            "graceful-fs": "^4.1.2",
+            "minimatch": "^3.0.2",
+            "mkdirp": "^0.5.0",
+            "nopt": "2 || 3",
+            "npmlog": "0 || 1 || 2 || 3 || 4",
+            "osenv": "0",
+            "request": "2",
+            "rimraf": "2",
+            "semver": "~5.3.0",
+            "tar": "^2.0.0",
+            "which": "1"
           },
           "dependencies": {
             "fstream": {
               "version": "1.0.11",
               "bundled": true,
               "requires": {
-                "graceful-fs": "4.1.11",
-                "inherits": "2.0.3",
-                "mkdirp": "0.5.1",
-                "rimraf": "2.6.2"
+                "graceful-fs": "^4.1.2",
+                "inherits": "~2.0.0",
+                "mkdirp": ">=0.5 0",
+                "rimraf": "2"
               }
             },
             "minimatch": {
               "version": "3.0.4",
               "bundled": true,
               "requires": {
-                "brace-expansion": "1.1.11"
+                "brace-expansion": "^1.1.7"
               },
               "dependencies": {
                 "brace-expansion": {
                   "version": "1.1.11",
                   "bundled": true,
                   "requires": {
-                    "balanced-match": "1.0.0",
+                    "balanced-match": "^1.0.0",
                     "concat-map": "0.0.1"
                   },
                   "dependencies": {
@@ -5836,7 +7711,7 @@
               "version": "3.0.6",
               "bundled": true,
               "requires": {
-                "abbrev": "1.1.1"
+                "abbrev": "1"
               }
             },
             "semver": {
@@ -5847,16 +7722,16 @@
               "version": "2.2.1",
               "bundled": true,
               "requires": {
-                "block-stream": "0.0.9",
-                "fstream": "1.0.11",
-                "inherits": "2.0.3"
+                "block-stream": "*",
+                "fstream": "^1.0.2",
+                "inherits": "2"
               },
               "dependencies": {
                 "block-stream": {
                   "version": "0.0.9",
                   "bundled": true,
                   "requires": {
-                    "inherits": "2.0.3"
+                    "inherits": "~2.0.0"
                   }
                 }
               }
@@ -5867,25 +7742,25 @@
           "version": "4.0.1",
           "bundled": true,
           "requires": {
-            "abbrev": "1.1.1",
-            "osenv": "0.1.5"
+            "abbrev": "1",
+            "osenv": "^0.1.4"
           }
         },
         "normalize-package-data": {
           "version": "2.4.0",
           "bundled": true,
           "requires": {
-            "hosted-git-info": "2.6.0",
-            "is-builtin-module": "1.0.0",
-            "semver": "5.5.0",
-            "validate-npm-package-license": "3.0.3"
+            "hosted-git-info": "^2.1.4",
+            "is-builtin-module": "^1.0.0",
+            "semver": "2 || 3 || 4 || 5",
+            "validate-npm-package-license": "^3.0.1"
           },
           "dependencies": {
             "is-builtin-module": {
               "version": "1.0.0",
               "bundled": true,
               "requires": {
-                "builtin-modules": "1.1.1"
+                "builtin-modules": "^1.0.0"
               },
               "dependencies": {
                 "builtin-modules": {
@@ -5900,8 +7775,8 @@
           "version": "1.0.8",
           "bundled": true,
           "requires": {
-            "cli-table2": "0.2.0",
-            "console-control-strings": "1.1.0"
+            "cli-table2": "^0.2.0",
+            "console-control-strings": "^1.1.0"
           },
           "dependencies": {
             "console-control-strings": {
@@ -5918,21 +7793,21 @@
           "version": "3.0.0",
           "bundled": true,
           "requires": {
-            "semver": "5.5.0"
+            "semver": "^2.3.0 || 3.x || 4 || 5"
           }
         },
         "npm-lifecycle": {
           "version": "2.0.1",
           "bundled": true,
           "requires": {
-            "byline": "5.0.0",
-            "graceful-fs": "4.1.11",
-            "node-gyp": "3.6.2",
-            "resolve-from": "4.0.0",
-            "slide": "1.1.6",
+            "byline": "^5.0.0",
+            "graceful-fs": "^4.1.11",
+            "node-gyp": "^3.6.2",
+            "resolve-from": "^4.0.0",
+            "slide": "^1.1.6",
             "uid-number": "0.0.6",
-            "umask": "1.1.0",
-            "which": "1.3.0"
+            "umask": "^1.1.0",
+            "which": "^1.3.0"
           },
           "dependencies": {
             "byline": {
@@ -5949,39 +7824,39 @@
           "version": "6.1.0",
           "bundled": true,
           "requires": {
-            "hosted-git-info": "2.6.0",
-            "osenv": "0.1.5",
-            "semver": "5.5.0",
-            "validate-npm-package-name": "3.0.0"
+            "hosted-git-info": "^2.6.0",
+            "osenv": "^0.1.5",
+            "semver": "^5.5.0",
+            "validate-npm-package-name": "^3.0.0"
           }
         },
         "npm-packlist": {
           "version": "1.1.10",
           "bundled": true,
           "requires": {
-            "ignore-walk": "3.0.1",
-            "npm-bundled": "1.0.3"
+            "ignore-walk": "^3.0.1",
+            "npm-bundled": "^1.0.1"
           },
           "dependencies": {
             "ignore-walk": {
               "version": "3.0.1",
               "bundled": true,
               "requires": {
-                "minimatch": "3.0.4"
+                "minimatch": "^3.0.4"
               },
               "dependencies": {
                 "minimatch": {
                   "version": "3.0.4",
                   "bundled": true,
                   "requires": {
-                    "brace-expansion": "1.1.8"
+                    "brace-expansion": "^1.1.7"
                   },
                   "dependencies": {
                     "brace-expansion": {
                       "version": "1.1.8",
                       "bundled": true,
                       "requires": {
-                        "balanced-match": "1.0.0",
+                        "balanced-match": "^1.0.0",
                         "concat-map": "0.0.1"
                       },
                       "dependencies": {
@@ -6009,47 +7884,47 @@
           "version": "2.1.0",
           "bundled": true,
           "requires": {
-            "npm-package-arg": "6.1.0",
-            "semver": "5.5.0"
+            "npm-package-arg": "^6.0.0",
+            "semver": "^5.4.1"
           }
         },
         "npm-profile": {
           "version": "3.0.1",
           "bundled": true,
           "requires": {
-            "aproba": "1.2.0",
-            "make-fetch-happen": "2.6.0"
+            "aproba": "^1.1.2",
+            "make-fetch-happen": "^2.5.0"
           },
           "dependencies": {
             "make-fetch-happen": {
               "version": "2.6.0",
               "bundled": true,
               "requires": {
-                "agentkeepalive": "3.3.0",
-                "cacache": "10.0.4",
-                "http-cache-semantics": "3.8.1",
-                "http-proxy-agent": "2.0.0",
-                "https-proxy-agent": "2.1.1",
-                "lru-cache": "4.1.2",
-                "mississippi": "1.3.1",
-                "node-fetch-npm": "2.0.2",
-                "promise-retry": "1.1.1",
-                "socks-proxy-agent": "3.0.1",
-                "ssri": "5.3.0"
+                "agentkeepalive": "^3.3.0",
+                "cacache": "^10.0.0",
+                "http-cache-semantics": "^3.8.0",
+                "http-proxy-agent": "^2.0.0",
+                "https-proxy-agent": "^2.1.0",
+                "lru-cache": "^4.1.1",
+                "mississippi": "^1.2.0",
+                "node-fetch-npm": "^2.0.2",
+                "promise-retry": "^1.1.1",
+                "socks-proxy-agent": "^3.0.1",
+                "ssri": "^5.0.0"
               },
               "dependencies": {
                 "agentkeepalive": {
                   "version": "3.3.0",
                   "bundled": true,
                   "requires": {
-                    "humanize-ms": "1.2.1"
+                    "humanize-ms": "^1.2.1"
                   },
                   "dependencies": {
                     "humanize-ms": {
                       "version": "1.2.1",
                       "bundled": true,
                       "requires": {
-                        "ms": "2.1.1"
+                        "ms": "^2.0.0"
                       },
                       "dependencies": {
                         "ms": {
@@ -6064,45 +7939,45 @@
                   "version": "10.0.4",
                   "bundled": true,
                   "requires": {
-                    "bluebird": "3.5.1",
-                    "chownr": "1.0.1",
-                    "glob": "7.1.2",
-                    "graceful-fs": "4.1.11",
-                    "lru-cache": "4.1.2",
-                    "mississippi": "2.0.0",
-                    "mkdirp": "0.5.1",
-                    "move-concurrently": "1.0.1",
-                    "promise-inflight": "1.0.1",
-                    "rimraf": "2.6.2",
-                    "ssri": "5.3.0",
-                    "unique-filename": "1.1.0",
-                    "y18n": "4.0.0"
+                    "bluebird": "^3.5.1",
+                    "chownr": "^1.0.1",
+                    "glob": "^7.1.2",
+                    "graceful-fs": "^4.1.11",
+                    "lru-cache": "^4.1.1",
+                    "mississippi": "^2.0.0",
+                    "mkdirp": "^0.5.1",
+                    "move-concurrently": "^1.0.1",
+                    "promise-inflight": "^1.0.1",
+                    "rimraf": "^2.6.2",
+                    "ssri": "^5.2.4",
+                    "unique-filename": "^1.1.0",
+                    "y18n": "^4.0.0"
                   },
                   "dependencies": {
                     "mississippi": {
                       "version": "2.0.0",
                       "bundled": true,
                       "requires": {
-                        "concat-stream": "1.6.2",
-                        "duplexify": "3.5.4",
-                        "end-of-stream": "1.4.1",
-                        "flush-write-stream": "1.0.3",
-                        "from2": "2.3.0",
-                        "parallel-transform": "1.1.0",
-                        "pump": "2.0.1",
-                        "pumpify": "1.4.0",
-                        "stream-each": "1.2.2",
-                        "through2": "2.0.3"
+                        "concat-stream": "^1.5.0",
+                        "duplexify": "^3.4.2",
+                        "end-of-stream": "^1.1.0",
+                        "flush-write-stream": "^1.0.0",
+                        "from2": "^2.1.0",
+                        "parallel-transform": "^1.1.0",
+                        "pump": "^2.0.1",
+                        "pumpify": "^1.3.3",
+                        "stream-each": "^1.1.0",
+                        "through2": "^2.0.0"
                       },
                       "dependencies": {
                         "concat-stream": {
                           "version": "1.6.2",
                           "bundled": true,
                           "requires": {
-                            "buffer-from": "1.0.0",
-                            "inherits": "2.0.3",
-                            "readable-stream": "2.3.6",
-                            "typedarray": "0.0.6"
+                            "buffer-from": "^1.0.0",
+                            "inherits": "^2.0.3",
+                            "readable-stream": "^2.2.2",
+                            "typedarray": "^0.0.6"
                           },
                           "dependencies": {
                             "buffer-from": {
@@ -6119,10 +7994,10 @@
                           "version": "3.5.4",
                           "bundled": true,
                           "requires": {
-                            "end-of-stream": "1.4.1",
-                            "inherits": "2.0.3",
-                            "readable-stream": "2.3.6",
-                            "stream-shift": "1.0.0"
+                            "end-of-stream": "^1.0.0",
+                            "inherits": "^2.0.1",
+                            "readable-stream": "^2.0.0",
+                            "stream-shift": "^1.0.0"
                           },
                           "dependencies": {
                             "stream-shift": {
@@ -6135,32 +8010,32 @@
                           "version": "1.4.1",
                           "bundled": true,
                           "requires": {
-                            "once": "1.4.0"
+                            "once": "^1.4.0"
                           }
                         },
                         "flush-write-stream": {
                           "version": "1.0.3",
                           "bundled": true,
                           "requires": {
-                            "inherits": "2.0.3",
-                            "readable-stream": "2.3.6"
+                            "inherits": "^2.0.1",
+                            "readable-stream": "^2.0.4"
                           }
                         },
                         "from2": {
                           "version": "2.3.0",
                           "bundled": true,
                           "requires": {
-                            "inherits": "2.0.3",
-                            "readable-stream": "2.3.6"
+                            "inherits": "^2.0.1",
+                            "readable-stream": "^2.0.0"
                           }
                         },
                         "parallel-transform": {
                           "version": "1.1.0",
                           "bundled": true,
                           "requires": {
-                            "cyclist": "0.2.2",
-                            "inherits": "2.0.3",
-                            "readable-stream": "2.3.6"
+                            "cyclist": "~0.2.2",
+                            "inherits": "^2.0.3",
+                            "readable-stream": "^2.1.5"
                           },
                           "dependencies": {
                             "cyclist": {
@@ -6173,25 +8048,25 @@
                           "version": "2.0.1",
                           "bundled": true,
                           "requires": {
-                            "end-of-stream": "1.4.1",
-                            "once": "1.4.0"
+                            "end-of-stream": "^1.1.0",
+                            "once": "^1.3.1"
                           }
                         },
                         "pumpify": {
                           "version": "1.4.0",
                           "bundled": true,
                           "requires": {
-                            "duplexify": "3.5.4",
-                            "inherits": "2.0.3",
-                            "pump": "2.0.1"
+                            "duplexify": "^3.5.3",
+                            "inherits": "^2.0.3",
+                            "pump": "^2.0.0"
                           }
                         },
                         "stream-each": {
                           "version": "1.2.2",
                           "bundled": true,
                           "requires": {
-                            "end-of-stream": "1.4.1",
-                            "stream-shift": "1.0.0"
+                            "end-of-stream": "^1.1.0",
+                            "stream-shift": "^1.0.0"
                           },
                           "dependencies": {
                             "stream-shift": {
@@ -6204,8 +8079,8 @@
                           "version": "2.0.3",
                           "bundled": true,
                           "requires": {
-                            "readable-stream": "2.3.6",
-                            "xtend": "4.0.1"
+                            "readable-stream": "^2.1.5",
+                            "xtend": "~4.0.1"
                           },
                           "dependencies": {
                             "xtend": {
@@ -6230,22 +8105,22 @@
                   "version": "2.0.0",
                   "bundled": true,
                   "requires": {
-                    "agent-base": "4.2.0",
-                    "debug": "2.6.9"
+                    "agent-base": "4",
+                    "debug": "2"
                   },
                   "dependencies": {
                     "agent-base": {
                       "version": "4.2.0",
                       "bundled": true,
                       "requires": {
-                        "es6-promisify": "5.0.0"
+                        "es6-promisify": "^5.0.0"
                       },
                       "dependencies": {
                         "es6-promisify": {
                           "version": "5.0.0",
                           "bundled": true,
                           "requires": {
-                            "es6-promise": "4.2.4"
+                            "es6-promise": "^4.0.3"
                           },
                           "dependencies": {
                             "es6-promise": {
@@ -6275,22 +8150,22 @@
                   "version": "2.1.1",
                   "bundled": true,
                   "requires": {
-                    "agent-base": "4.2.0",
-                    "debug": "3.1.0"
+                    "agent-base": "^4.1.0",
+                    "debug": "^3.1.0"
                   },
                   "dependencies": {
                     "agent-base": {
                       "version": "4.2.0",
                       "bundled": true,
                       "requires": {
-                        "es6-promisify": "5.0.0"
+                        "es6-promisify": "^5.0.0"
                       },
                       "dependencies": {
                         "es6-promisify": {
                           "version": "5.0.0",
                           "bundled": true,
                           "requires": {
-                            "es6-promise": "4.2.4"
+                            "es6-promise": "^4.0.3"
                           },
                           "dependencies": {
                             "es6-promise": {
@@ -6320,25 +8195,25 @@
                   "version": "1.3.1",
                   "bundled": true,
                   "requires": {
-                    "concat-stream": "1.6.0",
-                    "duplexify": "3.5.3",
-                    "end-of-stream": "1.4.1",
-                    "flush-write-stream": "1.0.2",
-                    "from2": "2.3.0",
-                    "parallel-transform": "1.1.0",
-                    "pump": "1.0.3",
-                    "pumpify": "1.4.0",
-                    "stream-each": "1.2.2",
-                    "through2": "2.0.3"
+                    "concat-stream": "^1.5.0",
+                    "duplexify": "^3.4.2",
+                    "end-of-stream": "^1.1.0",
+                    "flush-write-stream": "^1.0.0",
+                    "from2": "^2.1.0",
+                    "parallel-transform": "^1.1.0",
+                    "pump": "^1.0.0",
+                    "pumpify": "^1.3.3",
+                    "stream-each": "^1.1.0",
+                    "through2": "^2.0.0"
                   },
                   "dependencies": {
                     "concat-stream": {
                       "version": "1.6.0",
                       "bundled": true,
                       "requires": {
-                        "inherits": "2.0.3",
-                        "readable-stream": "2.3.6",
-                        "typedarray": "0.0.6"
+                        "inherits": "^2.0.3",
+                        "readable-stream": "^2.2.2",
+                        "typedarray": "^0.0.6"
                       },
                       "dependencies": {
                         "typedarray": {
@@ -6351,10 +8226,10 @@
                       "version": "3.5.3",
                       "bundled": true,
                       "requires": {
-                        "end-of-stream": "1.4.1",
-                        "inherits": "2.0.3",
-                        "readable-stream": "2.3.6",
-                        "stream-shift": "1.0.0"
+                        "end-of-stream": "^1.0.0",
+                        "inherits": "^2.0.1",
+                        "readable-stream": "^2.0.0",
+                        "stream-shift": "^1.0.0"
                       },
                       "dependencies": {
                         "stream-shift": {
@@ -6367,32 +8242,32 @@
                       "version": "1.4.1",
                       "bundled": true,
                       "requires": {
-                        "once": "1.4.0"
+                        "once": "^1.4.0"
                       }
                     },
                     "flush-write-stream": {
                       "version": "1.0.2",
                       "bundled": true,
                       "requires": {
-                        "inherits": "2.0.3",
-                        "readable-stream": "2.3.6"
+                        "inherits": "^2.0.1",
+                        "readable-stream": "^2.0.4"
                       }
                     },
                     "from2": {
                       "version": "2.3.0",
                       "bundled": true,
                       "requires": {
-                        "inherits": "2.0.3",
-                        "readable-stream": "2.3.6"
+                        "inherits": "^2.0.1",
+                        "readable-stream": "^2.0.0"
                       }
                     },
                     "parallel-transform": {
                       "version": "1.1.0",
                       "bundled": true,
                       "requires": {
-                        "cyclist": "0.2.2",
-                        "inherits": "2.0.3",
-                        "readable-stream": "2.3.6"
+                        "cyclist": "~0.2.2",
+                        "inherits": "^2.0.3",
+                        "readable-stream": "^2.1.5"
                       },
                       "dependencies": {
                         "cyclist": {
@@ -6405,25 +8280,25 @@
                       "version": "1.0.3",
                       "bundled": true,
                       "requires": {
-                        "end-of-stream": "1.4.1",
-                        "once": "1.4.0"
+                        "end-of-stream": "^1.1.0",
+                        "once": "^1.3.1"
                       }
                     },
                     "pumpify": {
                       "version": "1.4.0",
                       "bundled": true,
                       "requires": {
-                        "duplexify": "3.5.3",
-                        "inherits": "2.0.3",
-                        "pump": "2.0.1"
+                        "duplexify": "^3.5.3",
+                        "inherits": "^2.0.3",
+                        "pump": "^2.0.0"
                       },
                       "dependencies": {
                         "pump": {
                           "version": "2.0.1",
                           "bundled": true,
                           "requires": {
-                            "end-of-stream": "1.4.1",
-                            "once": "1.4.0"
+                            "end-of-stream": "^1.1.0",
+                            "once": "^1.3.1"
                           }
                         }
                       }
@@ -6432,8 +8307,8 @@
                       "version": "1.2.2",
                       "bundled": true,
                       "requires": {
-                        "end-of-stream": "1.4.1",
-                        "stream-shift": "1.0.0"
+                        "end-of-stream": "^1.1.0",
+                        "stream-shift": "^1.0.0"
                       },
                       "dependencies": {
                         "stream-shift": {
@@ -6446,8 +8321,8 @@
                       "version": "2.0.3",
                       "bundled": true,
                       "requires": {
-                        "readable-stream": "2.3.6",
-                        "xtend": "4.0.1"
+                        "readable-stream": "^2.1.5",
+                        "xtend": "~4.0.1"
                       },
                       "dependencies": {
                         "xtend": {
@@ -6462,16 +8337,16 @@
                   "version": "2.0.2",
                   "bundled": true,
                   "requires": {
-                    "encoding": "0.1.12",
-                    "json-parse-better-errors": "1.0.1",
-                    "safe-buffer": "5.1.2"
+                    "encoding": "^0.1.11",
+                    "json-parse-better-errors": "^1.0.0",
+                    "safe-buffer": "^5.1.1"
                   },
                   "dependencies": {
                     "encoding": {
                       "version": "0.1.12",
                       "bundled": true,
                       "requires": {
-                        "iconv-lite": "0.4.19"
+                        "iconv-lite": "~0.4.13"
                       },
                       "dependencies": {
                         "iconv-lite": {
@@ -6490,8 +8365,8 @@
                   "version": "1.1.1",
                   "bundled": true,
                   "requires": {
-                    "err-code": "1.1.2",
-                    "retry": "0.10.1"
+                    "err-code": "^1.0.0",
+                    "retry": "^0.10.0"
                   },
                   "dependencies": {
                     "err-code": {
@@ -6508,22 +8383,22 @@
                   "version": "3.0.1",
                   "bundled": true,
                   "requires": {
-                    "agent-base": "4.2.0",
-                    "socks": "1.1.10"
+                    "agent-base": "^4.1.0",
+                    "socks": "^1.1.10"
                   },
                   "dependencies": {
                     "agent-base": {
                       "version": "4.2.0",
                       "bundled": true,
                       "requires": {
-                        "es6-promisify": "5.0.0"
+                        "es6-promisify": "^5.0.0"
                       },
                       "dependencies": {
                         "es6-promisify": {
                           "version": "5.0.0",
                           "bundled": true,
                           "requires": {
-                            "es6-promise": "4.2.4"
+                            "es6-promise": "^4.0.3"
                           },
                           "dependencies": {
                             "es6-promise": {
@@ -6538,8 +8413,8 @@
                       "version": "1.1.10",
                       "bundled": true,
                       "requires": {
-                        "ip": "1.1.5",
-                        "smart-buffer": "1.1.15"
+                        "ip": "^1.1.4",
+                        "smart-buffer": "^1.0.13"
                       },
                       "dependencies": {
                         "ip": {
@@ -6558,7 +8433,7 @@
                   "version": "5.3.0",
                   "bundled": true,
                   "requires": {
-                    "safe-buffer": "5.1.2"
+                    "safe-buffer": "^5.1.1"
                   }
                 }
               }
@@ -6569,27 +8444,27 @@
           "version": "8.5.1",
           "bundled": true,
           "requires": {
-            "concat-stream": "1.6.1",
-            "graceful-fs": "4.1.11",
-            "normalize-package-data": "2.4.0",
-            "npm-package-arg": "6.1.0",
-            "npmlog": "4.1.2",
-            "once": "1.4.0",
-            "request": "2.85.0",
-            "retry": "0.10.1",
-            "safe-buffer": "5.1.2",
-            "semver": "5.5.0",
-            "slide": "1.1.6",
-            "ssri": "5.3.0"
+            "concat-stream": "^1.5.2",
+            "graceful-fs": "^4.1.6",
+            "normalize-package-data": "~1.0.1 || ^2.0.0",
+            "npm-package-arg": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0",
+            "npmlog": "2 || ^3.1.0 || ^4.0.0",
+            "once": "^1.3.3",
+            "request": "^2.74.0",
+            "retry": "^0.10.0",
+            "safe-buffer": "^5.1.1",
+            "semver": "2 >=2.2.1 || 3.x || 4 || 5",
+            "slide": "^1.1.3",
+            "ssri": "^5.2.4"
           },
           "dependencies": {
             "concat-stream": {
               "version": "1.6.1",
               "bundled": true,
               "requires": {
-                "inherits": "2.0.3",
-                "readable-stream": "2.3.6",
-                "typedarray": "0.0.6"
+                "inherits": "^2.0.3",
+                "readable-stream": "^2.2.2",
+                "typedarray": "^0.0.6"
               },
               "dependencies": {
                 "typedarray": {
@@ -6606,7 +8481,7 @@
               "version": "5.3.0",
               "bundled": true,
               "requires": {
-                "safe-buffer": "5.1.2"
+                "safe-buffer": "^5.1.1"
               }
             }
           }
@@ -6615,12 +8490,12 @@
           "version": "1.1.0",
           "bundled": true,
           "requires": {
-            "bluebird": "3.5.1",
-            "figgy-pudding": "2.0.1",
-            "lru-cache": "4.1.2",
-            "make-fetch-happen": "3.0.0",
-            "npm-package-arg": "6.1.0",
-            "safe-buffer": "5.1.2"
+            "bluebird": "^3.5.1",
+            "figgy-pudding": "^2.0.1",
+            "lru-cache": "^4.1.2",
+            "make-fetch-happen": "^3.0.0",
+            "npm-package-arg": "^6.0.0",
+            "safe-buffer": "^5.1.1"
           },
           "dependencies": {
             "figgy-pudding": {
@@ -6631,31 +8506,31 @@
               "version": "3.0.0",
               "bundled": true,
               "requires": {
-                "agentkeepalive": "3.4.1",
-                "cacache": "10.0.4",
-                "http-cache-semantics": "3.8.1",
-                "http-proxy-agent": "2.1.0",
-                "https-proxy-agent": "2.2.1",
-                "lru-cache": "4.1.2",
-                "mississippi": "3.0.0",
-                "node-fetch-npm": "2.0.2",
-                "promise-retry": "1.1.1",
-                "socks-proxy-agent": "3.0.1",
-                "ssri": "5.3.0"
+                "agentkeepalive": "^3.4.1",
+                "cacache": "^10.0.4",
+                "http-cache-semantics": "^3.8.1",
+                "http-proxy-agent": "^2.1.0",
+                "https-proxy-agent": "^2.2.0",
+                "lru-cache": "^4.1.2",
+                "mississippi": "^3.0.0",
+                "node-fetch-npm": "^2.0.2",
+                "promise-retry": "^1.1.1",
+                "socks-proxy-agent": "^3.0.1",
+                "ssri": "^5.2.4"
               },
               "dependencies": {
                 "agentkeepalive": {
                   "version": "3.4.1",
                   "bundled": true,
                   "requires": {
-                    "humanize-ms": "1.2.1"
+                    "humanize-ms": "^1.2.1"
                   },
                   "dependencies": {
                     "humanize-ms": {
                       "version": "1.2.1",
                       "bundled": true,
                       "requires": {
-                        "ms": "2.1.1"
+                        "ms": "^2.0.0"
                       },
                       "dependencies": {
                         "ms": {
@@ -6670,45 +8545,45 @@
                   "version": "10.0.4",
                   "bundled": true,
                   "requires": {
-                    "bluebird": "3.5.1",
-                    "chownr": "1.0.1",
-                    "glob": "7.1.2",
-                    "graceful-fs": "4.1.11",
-                    "lru-cache": "4.1.2",
-                    "mississippi": "2.0.0",
-                    "mkdirp": "0.5.1",
-                    "move-concurrently": "1.0.1",
-                    "promise-inflight": "1.0.1",
-                    "rimraf": "2.6.2",
-                    "ssri": "5.3.0",
-                    "unique-filename": "1.1.0",
-                    "y18n": "4.0.0"
+                    "bluebird": "^3.5.1",
+                    "chownr": "^1.0.1",
+                    "glob": "^7.1.2",
+                    "graceful-fs": "^4.1.11",
+                    "lru-cache": "^4.1.1",
+                    "mississippi": "^2.0.0",
+                    "mkdirp": "^0.5.1",
+                    "move-concurrently": "^1.0.1",
+                    "promise-inflight": "^1.0.1",
+                    "rimraf": "^2.6.2",
+                    "ssri": "^5.2.4",
+                    "unique-filename": "^1.1.0",
+                    "y18n": "^4.0.0"
                   },
                   "dependencies": {
                     "mississippi": {
                       "version": "2.0.0",
                       "bundled": true,
                       "requires": {
-                        "concat-stream": "1.6.2",
-                        "duplexify": "3.5.4",
-                        "end-of-stream": "1.4.1",
-                        "flush-write-stream": "1.0.3",
-                        "from2": "2.3.0",
-                        "parallel-transform": "1.1.0",
-                        "pump": "2.0.1",
-                        "pumpify": "1.4.0",
-                        "stream-each": "1.2.2",
-                        "through2": "2.0.3"
+                        "concat-stream": "^1.5.0",
+                        "duplexify": "^3.4.2",
+                        "end-of-stream": "^1.1.0",
+                        "flush-write-stream": "^1.0.0",
+                        "from2": "^2.1.0",
+                        "parallel-transform": "^1.1.0",
+                        "pump": "^2.0.1",
+                        "pumpify": "^1.3.3",
+                        "stream-each": "^1.1.0",
+                        "through2": "^2.0.0"
                       },
                       "dependencies": {
                         "concat-stream": {
                           "version": "1.6.2",
                           "bundled": true,
                           "requires": {
-                            "buffer-from": "1.0.0",
-                            "inherits": "2.0.3",
-                            "readable-stream": "2.3.6",
-                            "typedarray": "0.0.6"
+                            "buffer-from": "^1.0.0",
+                            "inherits": "^2.0.3",
+                            "readable-stream": "^2.2.2",
+                            "typedarray": "^0.0.6"
                           },
                           "dependencies": {
                             "buffer-from": {
@@ -6725,10 +8600,10 @@
                           "version": "3.5.4",
                           "bundled": true,
                           "requires": {
-                            "end-of-stream": "1.4.1",
-                            "inherits": "2.0.3",
-                            "readable-stream": "2.3.6",
-                            "stream-shift": "1.0.0"
+                            "end-of-stream": "^1.0.0",
+                            "inherits": "^2.0.1",
+                            "readable-stream": "^2.0.0",
+                            "stream-shift": "^1.0.0"
                           },
                           "dependencies": {
                             "stream-shift": {
@@ -6741,32 +8616,32 @@
                           "version": "1.4.1",
                           "bundled": true,
                           "requires": {
-                            "once": "1.4.0"
+                            "once": "^1.4.0"
                           }
                         },
                         "flush-write-stream": {
                           "version": "1.0.3",
                           "bundled": true,
                           "requires": {
-                            "inherits": "2.0.3",
-                            "readable-stream": "2.3.6"
+                            "inherits": "^2.0.1",
+                            "readable-stream": "^2.0.4"
                           }
                         },
                         "from2": {
                           "version": "2.3.0",
                           "bundled": true,
                           "requires": {
-                            "inherits": "2.0.3",
-                            "readable-stream": "2.3.6"
+                            "inherits": "^2.0.1",
+                            "readable-stream": "^2.0.0"
                           }
                         },
                         "parallel-transform": {
                           "version": "1.1.0",
                           "bundled": true,
                           "requires": {
-                            "cyclist": "0.2.2",
-                            "inherits": "2.0.3",
-                            "readable-stream": "2.3.6"
+                            "cyclist": "~0.2.2",
+                            "inherits": "^2.0.3",
+                            "readable-stream": "^2.1.5"
                           },
                           "dependencies": {
                             "cyclist": {
@@ -6779,25 +8654,25 @@
                           "version": "2.0.1",
                           "bundled": true,
                           "requires": {
-                            "end-of-stream": "1.4.1",
-                            "once": "1.4.0"
+                            "end-of-stream": "^1.1.0",
+                            "once": "^1.3.1"
                           }
                         },
                         "pumpify": {
                           "version": "1.4.0",
                           "bundled": true,
                           "requires": {
-                            "duplexify": "3.5.4",
-                            "inherits": "2.0.3",
-                            "pump": "2.0.1"
+                            "duplexify": "^3.5.3",
+                            "inherits": "^2.0.3",
+                            "pump": "^2.0.0"
                           }
                         },
                         "stream-each": {
                           "version": "1.2.2",
                           "bundled": true,
                           "requires": {
-                            "end-of-stream": "1.4.1",
-                            "stream-shift": "1.0.0"
+                            "end-of-stream": "^1.1.0",
+                            "stream-shift": "^1.0.0"
                           },
                           "dependencies": {
                             "stream-shift": {
@@ -6810,8 +8685,8 @@
                           "version": "2.0.3",
                           "bundled": true,
                           "requires": {
-                            "readable-stream": "2.3.6",
-                            "xtend": "4.0.1"
+                            "readable-stream": "^2.1.5",
+                            "xtend": "~4.0.1"
                           },
                           "dependencies": {
                             "xtend": {
@@ -6836,7 +8711,7 @@
                   "version": "2.1.0",
                   "bundled": true,
                   "requires": {
-                    "agent-base": "4.2.0",
+                    "agent-base": "4",
                     "debug": "3.1.0"
                   },
                   "dependencies": {
@@ -6844,14 +8719,14 @@
                       "version": "4.2.0",
                       "bundled": true,
                       "requires": {
-                        "es6-promisify": "5.0.0"
+                        "es6-promisify": "^5.0.0"
                       },
                       "dependencies": {
                         "es6-promisify": {
                           "version": "5.0.0",
                           "bundled": true,
                           "requires": {
-                            "es6-promise": "4.2.4"
+                            "es6-promise": "^4.0.3"
                           },
                           "dependencies": {
                             "es6-promise": {
@@ -6881,22 +8756,22 @@
                   "version": "2.2.1",
                   "bundled": true,
                   "requires": {
-                    "agent-base": "4.2.0",
-                    "debug": "3.1.0"
+                    "agent-base": "^4.1.0",
+                    "debug": "^3.1.0"
                   },
                   "dependencies": {
                     "agent-base": {
                       "version": "4.2.0",
                       "bundled": true,
                       "requires": {
-                        "es6-promisify": "5.0.0"
+                        "es6-promisify": "^5.0.0"
                       },
                       "dependencies": {
                         "es6-promisify": {
                           "version": "5.0.0",
                           "bundled": true,
                           "requires": {
-                            "es6-promise": "4.2.4"
+                            "es6-promise": "^4.0.3"
                           },
                           "dependencies": {
                             "es6-promise": {
@@ -6926,23 +8801,23 @@
                   "version": "2.0.2",
                   "bundled": true,
                   "requires": {
-                    "encoding": "0.1.12",
-                    "json-parse-better-errors": "1.0.2",
-                    "safe-buffer": "5.1.2"
+                    "encoding": "^0.1.11",
+                    "json-parse-better-errors": "^1.0.0",
+                    "safe-buffer": "^5.1.1"
                   },
                   "dependencies": {
                     "encoding": {
                       "version": "0.1.12",
                       "bundled": true,
                       "requires": {
-                        "iconv-lite": "0.4.21"
+                        "iconv-lite": "~0.4.13"
                       },
                       "dependencies": {
                         "iconv-lite": {
                           "version": "0.4.21",
                           "bundled": true,
                           "requires": {
-                            "safer-buffer": "2.1.2"
+                            "safer-buffer": "^2.1.0"
                           },
                           "dependencies": {
                             "safer-buffer": {
@@ -6959,8 +8834,8 @@
                   "version": "1.1.1",
                   "bundled": true,
                   "requires": {
-                    "err-code": "1.1.2",
-                    "retry": "0.10.1"
+                    "err-code": "^1.0.0",
+                    "retry": "^0.10.0"
                   },
                   "dependencies": {
                     "err-code": {
@@ -6977,22 +8852,22 @@
                   "version": "3.0.1",
                   "bundled": true,
                   "requires": {
-                    "agent-base": "4.2.0",
-                    "socks": "1.1.10"
+                    "agent-base": "^4.1.0",
+                    "socks": "^1.1.10"
                   },
                   "dependencies": {
                     "agent-base": {
                       "version": "4.2.0",
                       "bundled": true,
                       "requires": {
-                        "es6-promisify": "5.0.0"
+                        "es6-promisify": "^5.0.0"
                       },
                       "dependencies": {
                         "es6-promisify": {
                           "version": "5.0.0",
                           "bundled": true,
                           "requires": {
-                            "es6-promise": "4.2.4"
+                            "es6-promise": "^4.0.3"
                           },
                           "dependencies": {
                             "es6-promise": {
@@ -7007,8 +8882,8 @@
                       "version": "1.1.10",
                       "bundled": true,
                       "requires": {
-                        "ip": "1.1.5",
-                        "smart-buffer": "1.1.15"
+                        "ip": "^1.1.4",
+                        "smart-buffer": "^1.0.13"
                       },
                       "dependencies": {
                         "ip": {
@@ -7027,7 +8902,7 @@
                   "version": "5.3.0",
                   "bundled": true,
                   "requires": {
-                    "safe-buffer": "5.1.2"
+                    "safe-buffer": "^5.1.1"
                   }
                 }
               }
@@ -7042,18 +8917,18 @@
           "version": "4.1.2",
           "bundled": true,
           "requires": {
-            "are-we-there-yet": "1.1.4",
-            "console-control-strings": "1.1.0",
-            "gauge": "2.7.4",
-            "set-blocking": "2.0.0"
+            "are-we-there-yet": "~1.1.2",
+            "console-control-strings": "~1.1.0",
+            "gauge": "~2.7.3",
+            "set-blocking": "~2.0.0"
           },
           "dependencies": {
             "are-we-there-yet": {
               "version": "1.1.4",
               "bundled": true,
               "requires": {
-                "delegates": "1.0.0",
-                "readable-stream": "2.3.6"
+                "delegates": "^1.0.0",
+                "readable-stream": "^2.0.6"
               },
               "dependencies": {
                 "delegates": {
@@ -7070,14 +8945,14 @@
               "version": "2.7.4",
               "bundled": true,
               "requires": {
-                "aproba": "1.2.0",
-                "console-control-strings": "1.1.0",
-                "has-unicode": "2.0.1",
-                "object-assign": "4.1.1",
-                "signal-exit": "3.0.2",
-                "string-width": "1.0.2",
-                "strip-ansi": "3.0.1",
-                "wide-align": "1.1.2"
+                "aproba": "^1.0.3",
+                "console-control-strings": "^1.0.0",
+                "has-unicode": "^2.0.0",
+                "object-assign": "^4.1.0",
+                "signal-exit": "^3.0.0",
+                "string-width": "^1.0.1",
+                "strip-ansi": "^3.0.1",
+                "wide-align": "^1.1.0"
               },
               "dependencies": {
                 "object-assign": {
@@ -7092,9 +8967,9 @@
                   "version": "1.0.2",
                   "bundled": true,
                   "requires": {
-                    "code-point-at": "1.1.0",
-                    "is-fullwidth-code-point": "1.0.0",
-                    "strip-ansi": "3.0.1"
+                    "code-point-at": "^1.0.0",
+                    "is-fullwidth-code-point": "^1.0.0",
+                    "strip-ansi": "^3.0.0"
                   },
                   "dependencies": {
                     "code-point-at": {
@@ -7105,7 +8980,7 @@
                       "version": "1.0.0",
                       "bundled": true,
                       "requires": {
-                        "number-is-nan": "1.0.1"
+                        "number-is-nan": "^1.0.0"
                       },
                       "dependencies": {
                         "number-is-nan": {
@@ -7120,7 +8995,7 @@
                   "version": "3.0.1",
                   "bundled": true,
                   "requires": {
-                    "ansi-regex": "2.1.1"
+                    "ansi-regex": "^2.0.0"
                   },
                   "dependencies": {
                     "ansi-regex": {
@@ -7133,7 +9008,7 @@
                   "version": "1.1.2",
                   "bundled": true,
                   "requires": {
-                    "string-width": "1.0.2"
+                    "string-width": "^1.0.2"
                   }
                 }
               }
@@ -7148,7 +9023,7 @@
           "version": "1.4.0",
           "bundled": true,
           "requires": {
-            "wrappy": "1.0.2"
+            "wrappy": "1"
           }
         },
         "opener": {
@@ -7159,8 +9034,8 @@
           "version": "0.1.5",
           "bundled": true,
           "requires": {
-            "os-homedir": "1.0.2",
-            "os-tmpdir": "1.0.2"
+            "os-homedir": "^1.0.0",
+            "os-tmpdir": "^1.0.0"
           },
           "dependencies": {
             "os-homedir": {
@@ -7177,30 +9052,30 @@
           "version": "8.1.1",
           "bundled": true,
           "requires": {
-            "bluebird": "3.5.1",
-            "cacache": "11.0.1",
-            "get-stream": "3.0.0",
-            "glob": "7.1.2",
-            "lru-cache": "4.1.2",
-            "make-fetch-happen": "4.0.1",
-            "minimatch": "3.0.4",
-            "mississippi": "3.0.0",
-            "mkdirp": "0.5.1",
-            "normalize-package-data": "2.4.0",
-            "npm-package-arg": "6.1.0",
-            "npm-packlist": "1.1.10",
-            "npm-pick-manifest": "2.1.0",
-            "osenv": "0.1.5",
-            "promise-inflight": "1.0.1",
-            "promise-retry": "1.1.1",
-            "protoduck": "5.0.0",
-            "rimraf": "2.6.2",
-            "safe-buffer": "5.1.2",
-            "semver": "5.5.0",
-            "ssri": "6.0.0",
-            "tar": "4.4.2",
-            "unique-filename": "1.1.0",
-            "which": "1.3.0"
+            "bluebird": "^3.5.1",
+            "cacache": "^11.0.1",
+            "get-stream": "^3.0.0",
+            "glob": "^7.1.2",
+            "lru-cache": "^4.1.2",
+            "make-fetch-happen": "^4.0.1",
+            "minimatch": "^3.0.4",
+            "mississippi": "^3.0.0",
+            "mkdirp": "^0.5.1",
+            "normalize-package-data": "^2.4.0",
+            "npm-package-arg": "^6.1.0",
+            "npm-packlist": "^1.1.10",
+            "npm-pick-manifest": "^2.1.0",
+            "osenv": "^0.1.5",
+            "promise-inflight": "^1.0.1",
+            "promise-retry": "^1.1.1",
+            "protoduck": "^5.0.0",
+            "rimraf": "^2.6.2",
+            "safe-buffer": "^5.1.1",
+            "semver": "^5.5.0",
+            "ssri": "^6.0.0",
+            "tar": "^4.4.1",
+            "unique-filename": "^1.1.0",
+            "which": "^1.3.0"
           },
           "dependencies": {
             "get-stream": {
@@ -7211,31 +9086,31 @@
               "version": "4.0.1",
               "bundled": true,
               "requires": {
-                "agentkeepalive": "3.4.1",
-                "cacache": "11.0.1",
-                "http-cache-semantics": "3.8.1",
-                "http-proxy-agent": "2.1.0",
-                "https-proxy-agent": "2.2.1",
-                "lru-cache": "4.1.2",
-                "mississippi": "3.0.0",
-                "node-fetch-npm": "2.0.2",
-                "promise-retry": "1.1.1",
-                "socks-proxy-agent": "4.0.1",
-                "ssri": "6.0.0"
+                "agentkeepalive": "^3.4.1",
+                "cacache": "^11.0.1",
+                "http-cache-semantics": "^3.8.1",
+                "http-proxy-agent": "^2.1.0",
+                "https-proxy-agent": "^2.2.1",
+                "lru-cache": "^4.1.2",
+                "mississippi": "^3.0.0",
+                "node-fetch-npm": "^2.0.2",
+                "promise-retry": "^1.1.1",
+                "socks-proxy-agent": "^4.0.0",
+                "ssri": "^6.0.0"
               },
               "dependencies": {
                 "agentkeepalive": {
                   "version": "3.4.1",
                   "bundled": true,
                   "requires": {
-                    "humanize-ms": "1.2.1"
+                    "humanize-ms": "^1.2.1"
                   },
                   "dependencies": {
                     "humanize-ms": {
                       "version": "1.2.1",
                       "bundled": true,
                       "requires": {
-                        "ms": "2.1.1"
+                        "ms": "^2.0.0"
                       },
                       "dependencies": {
                         "ms": {
@@ -7254,7 +9129,7 @@
                   "version": "2.1.0",
                   "bundled": true,
                   "requires": {
-                    "agent-base": "4.2.0",
+                    "agent-base": "4",
                     "debug": "3.1.0"
                   },
                   "dependencies": {
@@ -7262,14 +9137,14 @@
                       "version": "4.2.0",
                       "bundled": true,
                       "requires": {
-                        "es6-promisify": "5.0.0"
+                        "es6-promisify": "^5.0.0"
                       },
                       "dependencies": {
                         "es6-promisify": {
                           "version": "5.0.0",
                           "bundled": true,
                           "requires": {
-                            "es6-promise": "4.2.4"
+                            "es6-promise": "^4.0.3"
                           },
                           "dependencies": {
                             "es6-promise": {
@@ -7299,22 +9174,22 @@
                   "version": "2.2.1",
                   "bundled": true,
                   "requires": {
-                    "agent-base": "4.2.0",
-                    "debug": "3.1.0"
+                    "agent-base": "^4.1.0",
+                    "debug": "^3.1.0"
                   },
                   "dependencies": {
                     "agent-base": {
                       "version": "4.2.0",
                       "bundled": true,
                       "requires": {
-                        "es6-promisify": "5.0.0"
+                        "es6-promisify": "^5.0.0"
                       },
                       "dependencies": {
                         "es6-promisify": {
                           "version": "5.0.0",
                           "bundled": true,
                           "requires": {
-                            "es6-promise": "4.2.4"
+                            "es6-promise": "^4.0.3"
                           },
                           "dependencies": {
                             "es6-promise": {
@@ -7344,23 +9219,23 @@
                   "version": "2.0.2",
                   "bundled": true,
                   "requires": {
-                    "encoding": "0.1.12",
-                    "json-parse-better-errors": "1.0.2",
-                    "safe-buffer": "5.1.2"
+                    "encoding": "^0.1.11",
+                    "json-parse-better-errors": "^1.0.0",
+                    "safe-buffer": "^5.1.1"
                   },
                   "dependencies": {
                     "encoding": {
                       "version": "0.1.12",
                       "bundled": true,
                       "requires": {
-                        "iconv-lite": "0.4.21"
+                        "iconv-lite": "~0.4.13"
                       },
                       "dependencies": {
                         "iconv-lite": {
                           "version": "0.4.21",
                           "bundled": true,
                           "requires": {
-                            "safer-buffer": "2.1.2"
+                            "safer-buffer": "^2.1.0"
                           },
                           "dependencies": {
                             "safer-buffer": {
@@ -7377,22 +9252,22 @@
                   "version": "4.0.1",
                   "bundled": true,
                   "requires": {
-                    "agent-base": "4.2.0",
-                    "socks": "2.2.0"
+                    "agent-base": "~4.2.0",
+                    "socks": "~2.2.0"
                   },
                   "dependencies": {
                     "agent-base": {
                       "version": "4.2.0",
                       "bundled": true,
                       "requires": {
-                        "es6-promisify": "5.0.0"
+                        "es6-promisify": "^5.0.0"
                       },
                       "dependencies": {
                         "es6-promisify": {
                           "version": "5.0.0",
                           "bundled": true,
                           "requires": {
-                            "es6-promise": "4.2.4"
+                            "es6-promise": "^4.0.3"
                           },
                           "dependencies": {
                             "es6-promise": {
@@ -7407,8 +9282,8 @@
                       "version": "2.2.0",
                       "bundled": true,
                       "requires": {
-                        "ip": "1.1.5",
-                        "smart-buffer": "4.0.1"
+                        "ip": "^1.1.5",
+                        "smart-buffer": "^4.0.1"
                       },
                       "dependencies": {
                         "ip": {
@@ -7429,14 +9304,14 @@
               "version": "3.0.4",
               "bundled": true,
               "requires": {
-                "brace-expansion": "1.1.11"
+                "brace-expansion": "^1.1.7"
               },
               "dependencies": {
                 "brace-expansion": {
                   "version": "1.1.11",
                   "bundled": true,
                   "requires": {
-                    "balanced-match": "1.0.0",
+                    "balanced-match": "^1.0.0",
                     "concat-map": "0.0.1"
                   },
                   "dependencies": {
@@ -7456,8 +9331,8 @@
               "version": "1.1.1",
               "bundled": true,
               "requires": {
-                "err-code": "1.1.2",
-                "retry": "0.10.1"
+                "err-code": "^1.0.0",
+                "retry": "^0.10.0"
               },
               "dependencies": {
                 "err-code": {
@@ -7474,7 +9349,7 @@
               "version": "5.0.0",
               "bundled": true,
               "requires": {
-                "genfun": "4.0.1"
+                "genfun": "^4.0.1"
               },
               "dependencies": {
                 "genfun": {
@@ -7501,8 +9376,8 @@
           "version": "6.1.0",
           "bundled": true,
           "requires": {
-            "decode-uri-component": "0.2.0",
-            "strict-uri-encode": "2.0.0"
+            "decode-uri-component": "^0.2.0",
+            "strict-uri-encode": "^2.0.0"
           },
           "dependencies": {
             "decode-uri-component": {
@@ -7523,7 +9398,7 @@
           "version": "1.0.7",
           "bundled": true,
           "requires": {
-            "mute-stream": "0.0.7"
+            "mute-stream": "~0.0.4"
           },
           "dependencies": {
             "mute-stream": {
@@ -7536,20 +9411,20 @@
           "version": "1.0.1",
           "bundled": true,
           "requires": {
-            "graceful-fs": "4.1.11"
+            "graceful-fs": "^4.1.2"
           }
         },
         "read-installed": {
           "version": "4.0.3",
           "bundled": true,
           "requires": {
-            "debuglog": "1.0.1",
-            "graceful-fs": "4.1.11",
-            "read-package-json": "2.0.13",
-            "readdir-scoped-modules": "1.0.2",
-            "semver": "5.5.0",
-            "slide": "1.1.6",
-            "util-extend": "1.0.3"
+            "debuglog": "^1.0.1",
+            "graceful-fs": "^4.1.2",
+            "read-package-json": "^2.0.0",
+            "readdir-scoped-modules": "^1.0.0",
+            "semver": "2 || 3 || 4 || 5",
+            "slide": "~1.1.3",
+            "util-extend": "^1.0.1"
           },
           "dependencies": {
             "util-extend": {
@@ -7562,11 +9437,11 @@
           "version": "2.0.13",
           "bundled": true,
           "requires": {
-            "glob": "7.1.2",
-            "graceful-fs": "4.1.11",
-            "json-parse-better-errors": "1.0.1",
-            "normalize-package-data": "2.4.0",
-            "slash": "1.0.0"
+            "glob": "^7.1.1",
+            "graceful-fs": "^4.1.2",
+            "json-parse-better-errors": "^1.0.1",
+            "normalize-package-data": "^2.0.0",
+            "slash": "^1.0.0"
           },
           "dependencies": {
             "json-parse-better-errors": {
@@ -7583,24 +9458,24 @@
           "version": "5.2.1",
           "bundled": true,
           "requires": {
-            "debuglog": "1.0.1",
-            "dezalgo": "1.0.3",
-            "once": "1.4.0",
-            "read-package-json": "2.0.13",
-            "readdir-scoped-modules": "1.0.2"
+            "debuglog": "^1.0.1",
+            "dezalgo": "^1.0.0",
+            "once": "^1.3.0",
+            "read-package-json": "^2.0.0",
+            "readdir-scoped-modules": "^1.0.0"
           }
         },
         "readable-stream": {
           "version": "2.3.6",
           "bundled": true,
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "2.0.0",
-            "safe-buffer": "5.1.2",
-            "string_decoder": "1.1.1",
-            "util-deprecate": "1.0.2"
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
           },
           "dependencies": {
             "core-util-is": {
@@ -7619,7 +9494,7 @@
               "version": "1.1.1",
               "bundled": true,
               "requires": {
-                "safe-buffer": "5.1.2"
+                "safe-buffer": "~5.1.0"
               }
             },
             "util-deprecate": {
@@ -7632,38 +9507,38 @@
           "version": "1.0.2",
           "bundled": true,
           "requires": {
-            "debuglog": "1.0.1",
-            "dezalgo": "1.0.3",
-            "graceful-fs": "4.1.11",
-            "once": "1.4.0"
+            "debuglog": "^1.0.1",
+            "dezalgo": "^1.0.0",
+            "graceful-fs": "^4.1.2",
+            "once": "^1.3.0"
           }
         },
         "request": {
           "version": "2.85.0",
           "bundled": true,
           "requires": {
-            "aws-sign2": "0.7.0",
-            "aws4": "1.6.0",
-            "caseless": "0.12.0",
-            "combined-stream": "1.0.6",
-            "extend": "3.0.1",
-            "forever-agent": "0.6.1",
-            "form-data": "2.3.2",
-            "har-validator": "5.0.3",
-            "hawk": "6.0.2",
-            "http-signature": "1.2.0",
-            "is-typedarray": "1.0.0",
-            "isstream": "0.1.2",
-            "json-stringify-safe": "5.0.1",
-            "mime-types": "2.1.18",
-            "oauth-sign": "0.8.2",
-            "performance-now": "2.1.0",
-            "qs": "6.5.1",
-            "safe-buffer": "5.1.2",
-            "stringstream": "0.0.5",
-            "tough-cookie": "2.3.4",
-            "tunnel-agent": "0.6.0",
-            "uuid": "3.2.1"
+            "aws-sign2": "~0.7.0",
+            "aws4": "^1.6.0",
+            "caseless": "~0.12.0",
+            "combined-stream": "~1.0.5",
+            "extend": "~3.0.1",
+            "forever-agent": "~0.6.1",
+            "form-data": "~2.3.1",
+            "har-validator": "~5.0.3",
+            "hawk": "~6.0.2",
+            "http-signature": "~1.2.0",
+            "is-typedarray": "~1.0.0",
+            "isstream": "~0.1.2",
+            "json-stringify-safe": "~5.0.1",
+            "mime-types": "~2.1.17",
+            "oauth-sign": "~0.8.2",
+            "performance-now": "^2.1.0",
+            "qs": "~6.5.1",
+            "safe-buffer": "^5.1.1",
+            "stringstream": "~0.0.5",
+            "tough-cookie": "~2.3.3",
+            "tunnel-agent": "^0.6.0",
+            "uuid": "^3.1.0"
           },
           "dependencies": {
             "aws-sign2": {
@@ -7682,7 +9557,7 @@
               "version": "1.0.6",
               "bundled": true,
               "requires": {
-                "delayed-stream": "1.0.0"
+                "delayed-stream": "~1.0.0"
               },
               "dependencies": {
                 "delayed-stream": {
@@ -7703,9 +9578,9 @@
               "version": "2.3.2",
               "bundled": true,
               "requires": {
-                "asynckit": "0.4.0",
+                "asynckit": "^0.4.0",
                 "combined-stream": "1.0.6",
-                "mime-types": "2.1.18"
+                "mime-types": "^2.1.12"
               },
               "dependencies": {
                 "asynckit": {
@@ -7718,18 +9593,18 @@
               "version": "5.0.3",
               "bundled": true,
               "requires": {
-                "ajv": "5.5.2",
-                "har-schema": "2.0.0"
+                "ajv": "^5.1.0",
+                "har-schema": "^2.0.0"
               },
               "dependencies": {
                 "ajv": {
                   "version": "5.5.2",
                   "bundled": true,
                   "requires": {
-                    "co": "4.6.0",
-                    "fast-deep-equal": "1.1.0",
-                    "fast-json-stable-stringify": "2.0.0",
-                    "json-schema-traverse": "0.3.1"
+                    "co": "^4.6.0",
+                    "fast-deep-equal": "^1.0.0",
+                    "fast-json-stable-stringify": "^2.0.0",
+                    "json-schema-traverse": "^0.3.0"
                   },
                   "dependencies": {
                     "co": {
@@ -7760,31 +9635,31 @@
               "version": "6.0.2",
               "bundled": true,
               "requires": {
-                "boom": "4.3.1",
-                "cryptiles": "3.1.2",
-                "hoek": "4.2.1",
-                "sntp": "2.1.0"
+                "boom": "4.x.x",
+                "cryptiles": "3.x.x",
+                "hoek": "4.x.x",
+                "sntp": "2.x.x"
               },
               "dependencies": {
                 "boom": {
                   "version": "4.3.1",
                   "bundled": true,
                   "requires": {
-                    "hoek": "4.2.1"
+                    "hoek": "4.x.x"
                   }
                 },
                 "cryptiles": {
                   "version": "3.1.2",
                   "bundled": true,
                   "requires": {
-                    "boom": "5.2.0"
+                    "boom": "5.x.x"
                   },
                   "dependencies": {
                     "boom": {
                       "version": "5.2.0",
                       "bundled": true,
                       "requires": {
-                        "hoek": "4.2.1"
+                        "hoek": "4.x.x"
                       }
                     }
                   }
@@ -7797,7 +9672,7 @@
                   "version": "2.1.0",
                   "bundled": true,
                   "requires": {
-                    "hoek": "4.2.1"
+                    "hoek": "4.x.x"
                   }
                 }
               }
@@ -7806,9 +9681,9 @@
               "version": "1.2.0",
               "bundled": true,
               "requires": {
-                "assert-plus": "1.0.0",
-                "jsprim": "1.4.1",
-                "sshpk": "1.14.1"
+                "assert-plus": "^1.0.0",
+                "jsprim": "^1.2.2",
+                "sshpk": "^1.7.0"
               },
               "dependencies": {
                 "assert-plus": {
@@ -7837,9 +9712,9 @@
                       "version": "1.10.0",
                       "bundled": true,
                       "requires": {
-                        "assert-plus": "1.0.0",
+                        "assert-plus": "^1.0.0",
                         "core-util-is": "1.0.2",
-                        "extsprintf": "1.3.0"
+                        "extsprintf": "^1.2.0"
                       },
                       "dependencies": {
                         "core-util-is": {
@@ -7854,14 +9729,14 @@
                   "version": "1.14.1",
                   "bundled": true,
                   "requires": {
-                    "asn1": "0.2.3",
-                    "assert-plus": "1.0.0",
-                    "bcrypt-pbkdf": "1.0.1",
-                    "dashdash": "1.14.1",
-                    "ecc-jsbn": "0.1.1",
-                    "getpass": "0.1.7",
-                    "jsbn": "0.1.1",
-                    "tweetnacl": "0.14.5"
+                    "asn1": "~0.2.3",
+                    "assert-plus": "^1.0.0",
+                    "bcrypt-pbkdf": "^1.0.0",
+                    "dashdash": "^1.12.0",
+                    "ecc-jsbn": "~0.1.1",
+                    "getpass": "^0.1.1",
+                    "jsbn": "~0.1.0",
+                    "tweetnacl": "~0.14.0"
                   },
                   "dependencies": {
                     "asn1": {
@@ -7873,14 +9748,14 @@
                       "bundled": true,
                       "optional": true,
                       "requires": {
-                        "tweetnacl": "0.14.5"
+                        "tweetnacl": "^0.14.3"
                       }
                     },
                     "dashdash": {
                       "version": "1.14.1",
                       "bundled": true,
                       "requires": {
-                        "assert-plus": "1.0.0"
+                        "assert-plus": "^1.0.0"
                       }
                     },
                     "ecc-jsbn": {
@@ -7888,14 +9763,14 @@
                       "bundled": true,
                       "optional": true,
                       "requires": {
-                        "jsbn": "0.1.1"
+                        "jsbn": "~0.1.0"
                       }
                     },
                     "getpass": {
                       "version": "0.1.7",
                       "bundled": true,
                       "requires": {
-                        "assert-plus": "1.0.0"
+                        "assert-plus": "^1.0.0"
                       }
                     },
                     "jsbn": {
@@ -7928,7 +9803,7 @@
               "version": "2.1.18",
               "bundled": true,
               "requires": {
-                "mime-db": "1.33.0"
+                "mime-db": "~1.33.0"
               },
               "dependencies": {
                 "mime-db": {
@@ -7957,7 +9832,7 @@
               "version": "2.3.4",
               "bundled": true,
               "requires": {
-                "punycode": "1.4.1"
+                "punycode": "^1.4.1"
               },
               "dependencies": {
                 "punycode": {
@@ -7970,7 +9845,7 @@
               "version": "0.6.0",
               "bundled": true,
               "requires": {
-                "safe-buffer": "5.1.2"
+                "safe-buffer": "^5.0.1"
               }
             }
           }
@@ -7983,7 +9858,7 @@
           "version": "2.6.2",
           "bundled": true,
           "requires": {
-            "glob": "7.1.2"
+            "glob": "^7.0.5"
           }
         },
         "safe-buffer": {
@@ -7998,8 +9873,8 @@
           "version": "2.0.1",
           "bundled": true,
           "requires": {
-            "graceful-fs": "4.1.11",
-            "readable-stream": "2.3.6"
+            "graceful-fs": "^4.1.2",
+            "readable-stream": "^2.0.2"
           }
         },
         "slide": {
@@ -8014,26 +9889,26 @@
           "version": "2.1.3",
           "bundled": true,
           "requires": {
-            "from2": "1.3.0",
-            "stream-iterate": "1.2.0"
+            "from2": "^1.3.0",
+            "stream-iterate": "^1.1.0"
           },
           "dependencies": {
             "from2": {
               "version": "1.3.0",
               "bundled": true,
               "requires": {
-                "inherits": "2.0.3",
-                "readable-stream": "1.1.14"
+                "inherits": "~2.0.1",
+                "readable-stream": "~1.1.10"
               },
               "dependencies": {
                 "readable-stream": {
                   "version": "1.1.14",
                   "bundled": true,
                   "requires": {
-                    "core-util-is": "1.0.2",
-                    "inherits": "2.0.3",
+                    "core-util-is": "~1.0.0",
+                    "inherits": "~2.0.1",
                     "isarray": "0.0.1",
-                    "string_decoder": "0.10.31"
+                    "string_decoder": "~0.10.x"
                   },
                   "dependencies": {
                     "core-util-is": {
@@ -8056,8 +9931,8 @@
               "version": "1.2.0",
               "bundled": true,
               "requires": {
-                "readable-stream": "2.3.6",
-                "stream-shift": "1.0.0"
+                "readable-stream": "^2.1.5",
+                "stream-shift": "^1.0.0"
               },
               "dependencies": {
                 "stream-shift": {
@@ -8076,7 +9951,7 @@
           "version": "4.0.0",
           "bundled": true,
           "requires": {
-            "ansi-regex": "3.0.0"
+            "ansi-regex": "^3.0.0"
           },
           "dependencies": {
             "ansi-regex": {
@@ -8089,35 +9964,35 @@
           "version": "4.4.2",
           "bundled": true,
           "requires": {
-            "chownr": "1.0.1",
-            "fs-minipass": "1.2.5",
-            "minipass": "2.2.4",
-            "minizlib": "1.1.0",
-            "mkdirp": "0.5.1",
-            "safe-buffer": "5.1.2",
-            "yallist": "3.0.2"
+            "chownr": "^1.0.1",
+            "fs-minipass": "^1.2.5",
+            "minipass": "^2.2.4",
+            "minizlib": "^1.1.0",
+            "mkdirp": "^0.5.0",
+            "safe-buffer": "^5.1.2",
+            "yallist": "^3.0.2"
           },
           "dependencies": {
             "fs-minipass": {
               "version": "1.2.5",
               "bundled": true,
               "requires": {
-                "minipass": "2.2.4"
+                "minipass": "^2.2.1"
               }
             },
             "minipass": {
               "version": "2.2.4",
               "bundled": true,
               "requires": {
-                "safe-buffer": "5.1.2",
-                "yallist": "3.0.2"
+                "safe-buffer": "^5.1.1",
+                "yallist": "^3.0.0"
               }
             },
             "minizlib": {
               "version": "1.1.0",
               "bundled": true,
               "requires": {
-                "minipass": "2.2.4"
+                "minipass": "^2.2.1"
               }
             },
             "safe-buffer": {
@@ -8150,14 +10025,14 @@
           "version": "1.1.0",
           "bundled": true,
           "requires": {
-            "unique-slug": "2.0.0"
+            "unique-slug": "^2.0.0"
           },
           "dependencies": {
             "unique-slug": {
               "version": "2.0.0",
               "bundled": true,
               "requires": {
-                "imurmurhash": "0.1.4"
+                "imurmurhash": "^0.1.4"
               }
             }
           }
@@ -8170,36 +10045,36 @@
           "version": "2.5.0",
           "bundled": true,
           "requires": {
-            "boxen": "1.3.0",
-            "chalk": "2.4.1",
-            "configstore": "3.1.2",
-            "import-lazy": "2.1.0",
-            "is-ci": "1.1.0",
-            "is-installed-globally": "0.1.0",
-            "is-npm": "1.0.0",
-            "latest-version": "3.1.0",
-            "semver-diff": "2.1.0",
-            "xdg-basedir": "3.0.0"
+            "boxen": "^1.2.1",
+            "chalk": "^2.0.1",
+            "configstore": "^3.0.0",
+            "import-lazy": "^2.1.0",
+            "is-ci": "^1.0.10",
+            "is-installed-globally": "^0.1.0",
+            "is-npm": "^1.0.0",
+            "latest-version": "^3.0.0",
+            "semver-diff": "^2.0.0",
+            "xdg-basedir": "^3.0.0"
           },
           "dependencies": {
             "boxen": {
               "version": "1.3.0",
               "bundled": true,
               "requires": {
-                "ansi-align": "2.0.0",
-                "camelcase": "4.1.0",
-                "chalk": "2.4.1",
-                "cli-boxes": "1.0.0",
-                "string-width": "2.1.1",
-                "term-size": "1.2.0",
-                "widest-line": "2.0.0"
+                "ansi-align": "^2.0.0",
+                "camelcase": "^4.0.0",
+                "chalk": "^2.0.1",
+                "cli-boxes": "^1.0.0",
+                "string-width": "^2.0.0",
+                "term-size": "^1.2.0",
+                "widest-line": "^2.0.0"
               },
               "dependencies": {
                 "ansi-align": {
                   "version": "2.0.0",
                   "bundled": true,
                   "requires": {
-                    "string-width": "2.1.1"
+                    "string-width": "^2.0.0"
                   }
                 },
                 "camelcase": {
@@ -8214,8 +10089,8 @@
                   "version": "2.1.1",
                   "bundled": true,
                   "requires": {
-                    "is-fullwidth-code-point": "2.0.0",
-                    "strip-ansi": "4.0.0"
+                    "is-fullwidth-code-point": "^2.0.0",
+                    "strip-ansi": "^4.0.0"
                   },
                   "dependencies": {
                     "is-fullwidth-code-point": {
@@ -8228,36 +10103,36 @@
                   "version": "1.2.0",
                   "bundled": true,
                   "requires": {
-                    "execa": "0.7.0"
+                    "execa": "^0.7.0"
                   },
                   "dependencies": {
                     "execa": {
                       "version": "0.7.0",
                       "bundled": true,
                       "requires": {
-                        "cross-spawn": "5.1.0",
-                        "get-stream": "3.0.0",
-                        "is-stream": "1.1.0",
-                        "npm-run-path": "2.0.2",
-                        "p-finally": "1.0.0",
-                        "signal-exit": "3.0.2",
-                        "strip-eof": "1.0.0"
+                        "cross-spawn": "^5.0.1",
+                        "get-stream": "^3.0.0",
+                        "is-stream": "^1.1.0",
+                        "npm-run-path": "^2.0.0",
+                        "p-finally": "^1.0.0",
+                        "signal-exit": "^3.0.0",
+                        "strip-eof": "^1.0.0"
                       },
                       "dependencies": {
                         "cross-spawn": {
                           "version": "5.1.0",
                           "bundled": true,
                           "requires": {
-                            "lru-cache": "4.1.2",
-                            "shebang-command": "1.2.0",
-                            "which": "1.3.0"
+                            "lru-cache": "^4.0.1",
+                            "shebang-command": "^1.2.0",
+                            "which": "^1.2.9"
                           },
                           "dependencies": {
                             "shebang-command": {
                               "version": "1.2.0",
                               "bundled": true,
                               "requires": {
-                                "shebang-regex": "1.0.0"
+                                "shebang-regex": "^1.0.0"
                               },
                               "dependencies": {
                                 "shebang-regex": {
@@ -8280,7 +10155,7 @@
                           "version": "2.0.2",
                           "bundled": true,
                           "requires": {
-                            "path-key": "2.0.1"
+                            "path-key": "^2.0.0"
                           },
                           "dependencies": {
                             "path-key": {
@@ -8309,7 +10184,7 @@
                   "version": "2.0.0",
                   "bundled": true,
                   "requires": {
-                    "string-width": "2.1.1"
+                    "string-width": "^2.1.1"
                   }
                 }
               }
@@ -8318,23 +10193,23 @@
               "version": "2.4.1",
               "bundled": true,
               "requires": {
-                "ansi-styles": "3.2.1",
-                "escape-string-regexp": "1.0.5",
-                "supports-color": "5.4.0"
+                "ansi-styles": "^3.2.1",
+                "escape-string-regexp": "^1.0.5",
+                "supports-color": "^5.3.0"
               },
               "dependencies": {
                 "ansi-styles": {
                   "version": "3.2.1",
                   "bundled": true,
                   "requires": {
-                    "color-convert": "1.9.1"
+                    "color-convert": "^1.9.0"
                   },
                   "dependencies": {
                     "color-convert": {
                       "version": "1.9.1",
                       "bundled": true,
                       "requires": {
-                        "color-name": "1.1.3"
+                        "color-name": "^1.1.1"
                       },
                       "dependencies": {
                         "color-name": {
@@ -8353,7 +10228,7 @@
                   "version": "5.4.0",
                   "bundled": true,
                   "requires": {
-                    "has-flag": "3.0.0"
+                    "has-flag": "^3.0.0"
                   },
                   "dependencies": {
                     "has-flag": {
@@ -8368,19 +10243,19 @@
               "version": "3.1.2",
               "bundled": true,
               "requires": {
-                "dot-prop": "4.2.0",
-                "graceful-fs": "4.1.11",
-                "make-dir": "1.2.0",
-                "unique-string": "1.0.0",
-                "write-file-atomic": "2.3.0",
-                "xdg-basedir": "3.0.0"
+                "dot-prop": "^4.1.0",
+                "graceful-fs": "^4.1.2",
+                "make-dir": "^1.0.0",
+                "unique-string": "^1.0.0",
+                "write-file-atomic": "^2.0.0",
+                "xdg-basedir": "^3.0.0"
               },
               "dependencies": {
                 "dot-prop": {
                   "version": "4.2.0",
                   "bundled": true,
                   "requires": {
-                    "is-obj": "1.0.1"
+                    "is-obj": "^1.0.0"
                   },
                   "dependencies": {
                     "is-obj": {
@@ -8393,7 +10268,7 @@
                   "version": "1.2.0",
                   "bundled": true,
                   "requires": {
-                    "pify": "3.0.0"
+                    "pify": "^3.0.0"
                   },
                   "dependencies": {
                     "pify": {
@@ -8406,7 +10281,7 @@
                   "version": "1.0.0",
                   "bundled": true,
                   "requires": {
-                    "crypto-random-string": "1.0.0"
+                    "crypto-random-string": "^1.0.0"
                   },
                   "dependencies": {
                     "crypto-random-string": {
@@ -8425,7 +10300,7 @@
               "version": "1.1.0",
               "bundled": true,
               "requires": {
-                "ci-info": "1.1.3"
+                "ci-info": "^1.0.0"
               },
               "dependencies": {
                 "ci-info": {
@@ -8438,22 +10313,22 @@
               "version": "0.1.0",
               "bundled": true,
               "requires": {
-                "global-dirs": "0.1.1",
-                "is-path-inside": "1.0.1"
+                "global-dirs": "^0.1.0",
+                "is-path-inside": "^1.0.0"
               },
               "dependencies": {
                 "global-dirs": {
                   "version": "0.1.1",
                   "bundled": true,
                   "requires": {
-                    "ini": "1.3.5"
+                    "ini": "^1.3.4"
                   }
                 },
                 "is-path-inside": {
                   "version": "1.0.1",
                   "bundled": true,
                   "requires": {
-                    "path-is-inside": "1.0.2"
+                    "path-is-inside": "^1.0.1"
                   }
                 }
               }
@@ -8466,41 +10341,41 @@
               "version": "3.1.0",
               "bundled": true,
               "requires": {
-                "package-json": "4.0.1"
+                "package-json": "^4.0.0"
               },
               "dependencies": {
                 "package-json": {
                   "version": "4.0.1",
                   "bundled": true,
                   "requires": {
-                    "got": "6.7.1",
-                    "registry-auth-token": "3.3.2",
-                    "registry-url": "3.1.0",
-                    "semver": "5.5.0"
+                    "got": "^6.7.1",
+                    "registry-auth-token": "^3.0.1",
+                    "registry-url": "^3.0.3",
+                    "semver": "^5.1.0"
                   },
                   "dependencies": {
                     "got": {
                       "version": "6.7.1",
                       "bundled": true,
                       "requires": {
-                        "create-error-class": "3.0.2",
-                        "duplexer3": "0.1.4",
-                        "get-stream": "3.0.0",
-                        "is-redirect": "1.0.0",
-                        "is-retry-allowed": "1.1.0",
-                        "is-stream": "1.1.0",
-                        "lowercase-keys": "1.0.1",
-                        "safe-buffer": "5.1.2",
-                        "timed-out": "4.0.1",
-                        "unzip-response": "2.0.1",
-                        "url-parse-lax": "1.0.0"
+                        "create-error-class": "^3.0.0",
+                        "duplexer3": "^0.1.4",
+                        "get-stream": "^3.0.0",
+                        "is-redirect": "^1.0.0",
+                        "is-retry-allowed": "^1.0.0",
+                        "is-stream": "^1.0.0",
+                        "lowercase-keys": "^1.0.0",
+                        "safe-buffer": "^5.0.1",
+                        "timed-out": "^4.0.0",
+                        "unzip-response": "^2.0.1",
+                        "url-parse-lax": "^1.0.0"
                       },
                       "dependencies": {
                         "create-error-class": {
                           "version": "3.0.2",
                           "bundled": true,
                           "requires": {
-                            "capture-stack-trace": "1.0.0"
+                            "capture-stack-trace": "^1.0.0"
                           },
                           "dependencies": {
                             "capture-stack-trace": {
@@ -8545,7 +10420,7 @@
                           "version": "1.0.0",
                           "bundled": true,
                           "requires": {
-                            "prepend-http": "1.0.4"
+                            "prepend-http": "^1.0.1"
                           },
                           "dependencies": {
                             "prepend-http": {
@@ -8560,18 +10435,18 @@
                       "version": "3.3.2",
                       "bundled": true,
                       "requires": {
-                        "rc": "1.2.7",
-                        "safe-buffer": "5.1.2"
+                        "rc": "^1.1.6",
+                        "safe-buffer": "^5.0.1"
                       },
                       "dependencies": {
                         "rc": {
                           "version": "1.2.7",
                           "bundled": true,
                           "requires": {
-                            "deep-extend": "0.5.1",
-                            "ini": "1.3.5",
-                            "minimist": "1.2.0",
-                            "strip-json-comments": "2.0.1"
+                            "deep-extend": "^0.5.1",
+                            "ini": "~1.3.0",
+                            "minimist": "^1.2.0",
+                            "strip-json-comments": "~2.0.1"
                           },
                           "dependencies": {
                             "deep-extend": {
@@ -8594,17 +10469,17 @@
                       "version": "3.1.0",
                       "bundled": true,
                       "requires": {
-                        "rc": "1.2.7"
+                        "rc": "^1.0.1"
                       },
                       "dependencies": {
                         "rc": {
                           "version": "1.2.7",
                           "bundled": true,
                           "requires": {
-                            "deep-extend": "0.5.1",
-                            "ini": "1.3.5",
-                            "minimist": "1.2.0",
-                            "strip-json-comments": "2.0.1"
+                            "deep-extend": "^0.5.1",
+                            "ini": "~1.3.0",
+                            "minimist": "^1.2.0",
+                            "strip-json-comments": "~2.0.1"
                           },
                           "dependencies": {
                             "deep-extend": {
@@ -8631,7 +10506,7 @@
               "version": "2.1.0",
               "bundled": true,
               "requires": {
-                "semver": "5.5.0"
+                "semver": "^5.0.3"
               }
             },
             "xdg-basedir": {
@@ -8648,16 +10523,16 @@
           "version": "3.0.3",
           "bundled": true,
           "requires": {
-            "spdx-correct": "3.0.0",
-            "spdx-expression-parse": "3.0.0"
+            "spdx-correct": "^3.0.0",
+            "spdx-expression-parse": "^3.0.0"
           },
           "dependencies": {
             "spdx-correct": {
               "version": "3.0.0",
               "bundled": true,
               "requires": {
-                "spdx-expression-parse": "3.0.0",
-                "spdx-license-ids": "3.0.0"
+                "spdx-expression-parse": "^3.0.0",
+                "spdx-license-ids": "^3.0.0"
               },
               "dependencies": {
                 "spdx-license-ids": {
@@ -8670,8 +10545,8 @@
               "version": "3.0.0",
               "bundled": true,
               "requires": {
-                "spdx-exceptions": "2.1.0",
-                "spdx-license-ids": "3.0.0"
+                "spdx-exceptions": "^2.1.0",
+                "spdx-license-ids": "^3.0.0"
               },
               "dependencies": {
                 "spdx-exceptions": {
@@ -8690,7 +10565,7 @@
           "version": "3.0.0",
           "bundled": true,
           "requires": {
-            "builtins": "1.0.3"
+            "builtins": "^1.0.3"
           },
           "dependencies": {
             "builtins": {
@@ -8703,7 +10578,7 @@
           "version": "1.3.0",
           "bundled": true,
           "requires": {
-            "isexe": "2.0.0"
+            "isexe": "^2.0.0"
           },
           "dependencies": {
             "isexe": {
@@ -8716,14 +10591,14 @@
           "version": "1.6.0",
           "bundled": true,
           "requires": {
-            "errno": "0.1.7"
+            "errno": "~0.1.7"
           },
           "dependencies": {
             "errno": {
               "version": "0.1.7",
               "bundled": true,
               "requires": {
-                "prr": "1.0.1"
+                "prr": "~1.0.1"
               },
               "dependencies": {
                 "prr": {
@@ -8742,9 +10617,9 @@
           "version": "2.3.0",
           "bundled": true,
           "requires": {
-            "graceful-fs": "4.1.11",
-            "imurmurhash": "0.1.4",
-            "signal-exit": "3.0.2"
+            "graceful-fs": "^4.1.11",
+            "imurmurhash": "^0.1.4",
+            "signal-exit": "^3.0.2"
           },
           "dependencies": {
             "signal-exit": {
@@ -8760,7 +10635,7 @@
       "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
       "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
       "requires": {
-        "path-key": "2.0.1"
+        "path-key": "^2.0.0"
       }
     },
     "null-check": {
@@ -8779,33 +10654,33 @@
       "integrity": "sha512-PUFq1PSsx5OinSk5g5aaZygcDdI3QQT5XUlbR9QRMihtMS6w0Gm8xj4BxmKeeAlpQXC5M2DIhH16Y+KejceivQ==",
       "dev": true,
       "requires": {
-        "archy": "1.0.0",
-        "arrify": "1.0.1",
-        "caching-transform": "1.0.1",
-        "convert-source-map": "1.5.1",
-        "debug-log": "1.0.1",
-        "default-require-extensions": "1.0.0",
-        "find-cache-dir": "0.1.1",
-        "find-up": "2.1.0",
-        "foreground-child": "1.5.6",
-        "glob": "7.1.2",
-        "istanbul-lib-coverage": "1.2.0",
-        "istanbul-lib-hook": "1.1.0",
-        "istanbul-lib-instrument": "1.10.1",
-        "istanbul-lib-report": "1.1.3",
-        "istanbul-lib-source-maps": "1.2.3",
-        "istanbul-reports": "1.4.0",
-        "md5-hex": "1.3.0",
-        "merge-source-map": "1.1.0",
-        "micromatch": "3.1.10",
-        "mkdirp": "0.5.1",
-        "resolve-from": "2.0.0",
-        "rimraf": "2.6.2",
-        "signal-exit": "3.0.2",
-        "spawn-wrap": "1.4.2",
-        "test-exclude": "4.2.1",
+        "archy": "^1.0.0",
+        "arrify": "^1.0.1",
+        "caching-transform": "^1.0.0",
+        "convert-source-map": "^1.5.1",
+        "debug-log": "^1.0.1",
+        "default-require-extensions": "^1.0.0",
+        "find-cache-dir": "^0.1.1",
+        "find-up": "^2.1.0",
+        "foreground-child": "^1.5.3",
+        "glob": "^7.0.6",
+        "istanbul-lib-coverage": "^1.1.2",
+        "istanbul-lib-hook": "^1.1.0",
+        "istanbul-lib-instrument": "^1.10.0",
+        "istanbul-lib-report": "^1.1.3",
+        "istanbul-lib-source-maps": "^1.2.3",
+        "istanbul-reports": "^1.4.0",
+        "md5-hex": "^1.2.0",
+        "merge-source-map": "^1.1.0",
+        "micromatch": "^3.1.10",
+        "mkdirp": "^0.5.0",
+        "resolve-from": "^2.0.0",
+        "rimraf": "^2.6.2",
+        "signal-exit": "^3.0.1",
+        "spawn-wrap": "^1.4.2",
+        "test-exclude": "^4.2.0",
         "yargs": "11.1.0",
-        "yargs-parser": "8.1.0"
+        "yargs-parser": "^8.0.0"
       },
       "dependencies": {
         "align-text": {
@@ -8813,9 +10688,9 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "kind-of": "3.2.2",
-            "longest": "1.0.1",
-            "repeat-string": "1.6.1"
+            "kind-of": "^3.0.2",
+            "longest": "^1.0.1",
+            "repeat-string": "^1.5.2"
           }
         },
         "amdefine": {
@@ -8838,7 +10713,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "default-require-extensions": "1.0.0"
+            "default-require-extensions": "^1.0.0"
           }
         },
         "archy": {
@@ -8891,9 +10766,9 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "chalk": "1.1.3",
-            "esutils": "2.0.2",
-            "js-tokens": "3.0.2"
+            "chalk": "^1.1.3",
+            "esutils": "^2.0.2",
+            "js-tokens": "^3.0.2"
           }
         },
         "babel-generator": {
@@ -8901,14 +10776,14 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "babel-messages": "6.23.0",
-            "babel-runtime": "6.26.0",
-            "babel-types": "6.26.0",
-            "detect-indent": "4.0.0",
-            "jsesc": "1.3.0",
-            "lodash": "4.17.10",
-            "source-map": "0.5.7",
-            "trim-right": "1.0.1"
+            "babel-messages": "^6.23.0",
+            "babel-runtime": "^6.26.0",
+            "babel-types": "^6.26.0",
+            "detect-indent": "^4.0.0",
+            "jsesc": "^1.3.0",
+            "lodash": "^4.17.4",
+            "source-map": "^0.5.7",
+            "trim-right": "^1.0.1"
           }
         },
         "babel-messages": {
@@ -8916,7 +10791,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "babel-runtime": "6.26.0"
+            "babel-runtime": "^6.22.0"
           }
         },
         "babel-runtime": {
@@ -8924,8 +10799,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "core-js": "2.5.6",
-            "regenerator-runtime": "0.11.1"
+            "core-js": "^2.4.0",
+            "regenerator-runtime": "^0.11.0"
           }
         },
         "babel-template": {
@@ -8933,11 +10808,11 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "babel-runtime": "6.26.0",
-            "babel-traverse": "6.26.0",
-            "babel-types": "6.26.0",
-            "babylon": "6.18.0",
-            "lodash": "4.17.10"
+            "babel-runtime": "^6.26.0",
+            "babel-traverse": "^6.26.0",
+            "babel-types": "^6.26.0",
+            "babylon": "^6.18.0",
+            "lodash": "^4.17.4"
           }
         },
         "babel-traverse": {
@@ -8945,15 +10820,15 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "babel-code-frame": "6.26.0",
-            "babel-messages": "6.23.0",
-            "babel-runtime": "6.26.0",
-            "babel-types": "6.26.0",
-            "babylon": "6.18.0",
-            "debug": "2.6.9",
-            "globals": "9.18.0",
-            "invariant": "2.2.4",
-            "lodash": "4.17.10"
+            "babel-code-frame": "^6.26.0",
+            "babel-messages": "^6.23.0",
+            "babel-runtime": "^6.26.0",
+            "babel-types": "^6.26.0",
+            "babylon": "^6.18.0",
+            "debug": "^2.6.8",
+            "globals": "^9.18.0",
+            "invariant": "^2.2.2",
+            "lodash": "^4.17.4"
           }
         },
         "babel-types": {
@@ -8961,10 +10836,10 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "babel-runtime": "6.26.0",
-            "esutils": "2.0.2",
-            "lodash": "4.17.10",
-            "to-fast-properties": "1.0.3"
+            "babel-runtime": "^6.26.0",
+            "esutils": "^2.0.2",
+            "lodash": "^4.17.4",
+            "to-fast-properties": "^1.0.3"
           }
         },
         "babylon": {
@@ -8982,13 +10857,13 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "cache-base": "1.0.1",
-            "class-utils": "0.3.6",
-            "component-emitter": "1.2.1",
-            "define-property": "1.0.0",
-            "isobject": "3.0.1",
-            "mixin-deep": "1.3.1",
-            "pascalcase": "0.1.1"
+            "cache-base": "^1.0.1",
+            "class-utils": "^0.3.5",
+            "component-emitter": "^1.2.1",
+            "define-property": "^1.0.0",
+            "isobject": "^3.0.1",
+            "mixin-deep": "^1.2.0",
+            "pascalcase": "^0.1.1"
           },
           "dependencies": {
             "define-property": {
@@ -8996,7 +10871,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "is-descriptor": "1.0.2"
+                "is-descriptor": "^1.0.0"
               }
             },
             "is-accessor-descriptor": {
@@ -9004,7 +10879,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "kind-of": "6.0.2"
+                "kind-of": "^6.0.0"
               }
             },
             "is-data-descriptor": {
@@ -9012,7 +10887,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "kind-of": "6.0.2"
+                "kind-of": "^6.0.0"
               }
             },
             "is-descriptor": {
@@ -9020,9 +10895,9 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "is-accessor-descriptor": "1.0.0",
-                "is-data-descriptor": "1.0.0",
-                "kind-of": "6.0.2"
+                "is-accessor-descriptor": "^1.0.0",
+                "is-data-descriptor": "^1.0.0",
+                "kind-of": "^6.0.2"
               }
             },
             "isobject": {
@@ -9042,7 +10917,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "balanced-match": "1.0.0",
+            "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
           }
         },
@@ -9051,16 +10926,16 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "arr-flatten": "1.1.0",
-            "array-unique": "0.3.2",
-            "extend-shallow": "2.0.1",
-            "fill-range": "4.0.0",
-            "isobject": "3.0.1",
-            "repeat-element": "1.1.2",
-            "snapdragon": "0.8.2",
-            "snapdragon-node": "2.1.1",
-            "split-string": "3.1.0",
-            "to-regex": "3.0.2"
+            "arr-flatten": "^1.1.0",
+            "array-unique": "^0.3.2",
+            "extend-shallow": "^2.0.1",
+            "fill-range": "^4.0.0",
+            "isobject": "^3.0.1",
+            "repeat-element": "^1.1.2",
+            "snapdragon": "^0.8.1",
+            "snapdragon-node": "^2.0.1",
+            "split-string": "^3.0.2",
+            "to-regex": "^3.0.1"
           },
           "dependencies": {
             "extend-shallow": {
@@ -9068,7 +10943,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "is-extendable": "0.1.1"
+                "is-extendable": "^0.1.0"
               }
             }
           }
@@ -9083,15 +10958,15 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "collection-visit": "1.0.0",
-            "component-emitter": "1.2.1",
-            "get-value": "2.0.6",
-            "has-value": "1.0.0",
-            "isobject": "3.0.1",
-            "set-value": "2.0.0",
-            "to-object-path": "0.3.0",
-            "union-value": "1.0.0",
-            "unset-value": "1.0.0"
+            "collection-visit": "^1.0.0",
+            "component-emitter": "^1.2.1",
+            "get-value": "^2.0.6",
+            "has-value": "^1.0.0",
+            "isobject": "^3.0.1",
+            "set-value": "^2.0.0",
+            "to-object-path": "^0.3.0",
+            "union-value": "^1.0.0",
+            "unset-value": "^1.0.0"
           },
           "dependencies": {
             "isobject": {
@@ -9106,9 +10981,9 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "md5-hex": "1.3.0",
-            "mkdirp": "0.5.1",
-            "write-file-atomic": "1.3.4"
+            "md5-hex": "^1.2.0",
+            "mkdirp": "^0.5.1",
+            "write-file-atomic": "^1.1.4"
           }
         },
         "camelcase": {
@@ -9123,8 +10998,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "align-text": "0.1.4",
-            "lazy-cache": "1.0.4"
+            "align-text": "^0.1.3",
+            "lazy-cache": "^1.0.3"
           }
         },
         "chalk": {
@@ -9132,11 +11007,11 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
           }
         },
         "class-utils": {
@@ -9144,10 +11019,10 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "arr-union": "3.1.0",
-            "define-property": "0.2.5",
-            "isobject": "3.0.1",
-            "static-extend": "0.1.2"
+            "arr-union": "^3.1.0",
+            "define-property": "^0.2.5",
+            "isobject": "^3.0.0",
+            "static-extend": "^0.1.1"
           },
           "dependencies": {
             "define-property": {
@@ -9155,7 +11030,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "is-descriptor": "0.1.6"
+                "is-descriptor": "^0.1.0"
               }
             },
             "isobject": {
@@ -9171,8 +11046,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "center-align": "0.1.3",
-            "right-align": "0.1.3",
+            "center-align": "^0.1.1",
+            "right-align": "^0.1.1",
             "wordwrap": "0.0.2"
           },
           "dependencies": {
@@ -9194,8 +11069,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "map-visit": "1.0.0",
-            "object-visit": "1.0.1"
+            "map-visit": "^1.0.0",
+            "object-visit": "^1.0.0"
           }
         },
         "commondir": {
@@ -9233,8 +11108,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "lru-cache": "4.1.3",
-            "which": "1.3.0"
+            "lru-cache": "^4.0.1",
+            "which": "^1.2.9"
           }
         },
         "debug": {
@@ -9265,7 +11140,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "strip-bom": "2.0.0"
+            "strip-bom": "^2.0.0"
           }
         },
         "define-property": {
@@ -9273,8 +11148,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "is-descriptor": "1.0.2",
-            "isobject": "3.0.1"
+            "is-descriptor": "^1.0.2",
+            "isobject": "^3.0.1"
           },
           "dependencies": {
             "is-accessor-descriptor": {
@@ -9282,7 +11157,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "kind-of": "6.0.2"
+                "kind-of": "^6.0.0"
               }
             },
             "is-data-descriptor": {
@@ -9290,7 +11165,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "kind-of": "6.0.2"
+                "kind-of": "^6.0.0"
               }
             },
             "is-descriptor": {
@@ -9298,9 +11173,9 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "is-accessor-descriptor": "1.0.0",
-                "is-data-descriptor": "1.0.0",
-                "kind-of": "6.0.2"
+                "is-accessor-descriptor": "^1.0.0",
+                "is-data-descriptor": "^1.0.0",
+                "kind-of": "^6.0.2"
               }
             },
             "isobject": {
@@ -9320,7 +11195,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "repeating": "2.0.1"
+            "repeating": "^2.0.0"
           }
         },
         "error-ex": {
@@ -9328,7 +11203,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "is-arrayish": "0.2.1"
+            "is-arrayish": "^0.2.1"
           }
         },
         "escape-string-regexp": {
@@ -9346,13 +11221,13 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "cross-spawn": "5.1.0",
-            "get-stream": "3.0.0",
-            "is-stream": "1.1.0",
-            "npm-run-path": "2.0.2",
-            "p-finally": "1.0.0",
-            "signal-exit": "3.0.2",
-            "strip-eof": "1.0.0"
+            "cross-spawn": "^5.0.1",
+            "get-stream": "^3.0.0",
+            "is-stream": "^1.1.0",
+            "npm-run-path": "^2.0.0",
+            "p-finally": "^1.0.0",
+            "signal-exit": "^3.0.0",
+            "strip-eof": "^1.0.0"
           },
           "dependencies": {
             "cross-spawn": {
@@ -9360,9 +11235,9 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "lru-cache": "4.1.3",
-                "shebang-command": "1.2.0",
-                "which": "1.3.0"
+                "lru-cache": "^4.0.1",
+                "shebang-command": "^1.2.0",
+                "which": "^1.2.9"
               }
             }
           }
@@ -9372,13 +11247,13 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "debug": "2.6.9",
-            "define-property": "0.2.5",
-            "extend-shallow": "2.0.1",
-            "posix-character-classes": "0.1.1",
-            "regex-not": "1.0.2",
-            "snapdragon": "0.8.2",
-            "to-regex": "3.0.2"
+            "debug": "^2.3.3",
+            "define-property": "^0.2.5",
+            "extend-shallow": "^2.0.1",
+            "posix-character-classes": "^0.1.0",
+            "regex-not": "^1.0.0",
+            "snapdragon": "^0.8.1",
+            "to-regex": "^3.0.1"
           },
           "dependencies": {
             "define-property": {
@@ -9386,7 +11261,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "is-descriptor": "0.1.6"
+                "is-descriptor": "^0.1.0"
               }
             },
             "extend-shallow": {
@@ -9394,7 +11269,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "is-extendable": "0.1.1"
+                "is-extendable": "^0.1.0"
               }
             }
           }
@@ -9404,8 +11279,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "assign-symbols": "1.0.0",
-            "is-extendable": "1.0.1"
+            "assign-symbols": "^1.0.0",
+            "is-extendable": "^1.0.1"
           },
           "dependencies": {
             "is-extendable": {
@@ -9413,7 +11288,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "is-plain-object": "2.0.4"
+                "is-plain-object": "^2.0.4"
               }
             }
           }
@@ -9423,14 +11298,14 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "array-unique": "0.3.2",
-            "define-property": "1.0.0",
-            "expand-brackets": "2.1.4",
-            "extend-shallow": "2.0.1",
-            "fragment-cache": "0.2.1",
-            "regex-not": "1.0.2",
-            "snapdragon": "0.8.2",
-            "to-regex": "3.0.2"
+            "array-unique": "^0.3.2",
+            "define-property": "^1.0.0",
+            "expand-brackets": "^2.1.4",
+            "extend-shallow": "^2.0.1",
+            "fragment-cache": "^0.2.1",
+            "regex-not": "^1.0.0",
+            "snapdragon": "^0.8.1",
+            "to-regex": "^3.0.1"
           },
           "dependencies": {
             "define-property": {
@@ -9438,7 +11313,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "is-descriptor": "1.0.2"
+                "is-descriptor": "^1.0.0"
               }
             },
             "extend-shallow": {
@@ -9446,7 +11321,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "is-extendable": "0.1.1"
+                "is-extendable": "^0.1.0"
               }
             },
             "is-accessor-descriptor": {
@@ -9454,7 +11329,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "kind-of": "6.0.2"
+                "kind-of": "^6.0.0"
               }
             },
             "is-data-descriptor": {
@@ -9462,7 +11337,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "kind-of": "6.0.2"
+                "kind-of": "^6.0.0"
               }
             },
             "is-descriptor": {
@@ -9470,9 +11345,9 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "is-accessor-descriptor": "1.0.0",
-                "is-data-descriptor": "1.0.0",
-                "kind-of": "6.0.2"
+                "is-accessor-descriptor": "^1.0.0",
+                "is-data-descriptor": "^1.0.0",
+                "kind-of": "^6.0.2"
               }
             },
             "kind-of": {
@@ -9487,10 +11362,10 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "extend-shallow": "2.0.1",
-            "is-number": "3.0.0",
-            "repeat-string": "1.6.1",
-            "to-regex-range": "2.1.1"
+            "extend-shallow": "^2.0.1",
+            "is-number": "^3.0.0",
+            "repeat-string": "^1.6.1",
+            "to-regex-range": "^2.1.0"
           },
           "dependencies": {
             "extend-shallow": {
@@ -9498,7 +11373,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "is-extendable": "0.1.1"
+                "is-extendable": "^0.1.0"
               }
             }
           }
@@ -9508,9 +11383,9 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "commondir": "1.0.1",
-            "mkdirp": "0.5.1",
-            "pkg-dir": "1.0.0"
+            "commondir": "^1.0.1",
+            "mkdirp": "^0.5.1",
+            "pkg-dir": "^1.0.0"
           }
         },
         "find-up": {
@@ -9518,7 +11393,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "locate-path": "2.0.0"
+            "locate-path": "^2.0.0"
           }
         },
         "for-in": {
@@ -9531,8 +11406,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "cross-spawn": "4.0.2",
-            "signal-exit": "3.0.2"
+            "cross-spawn": "^4",
+            "signal-exit": "^3.0.0"
           }
         },
         "fragment-cache": {
@@ -9540,7 +11415,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "map-cache": "0.2.2"
+            "map-cache": "^0.2.2"
           }
         },
         "fs.realpath": {
@@ -9568,12 +11443,12 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         },
         "globals": {
@@ -9591,10 +11466,10 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "async": "1.5.2",
-            "optimist": "0.6.1",
-            "source-map": "0.4.4",
-            "uglify-js": "2.8.29"
+            "async": "^1.4.0",
+            "optimist": "^0.6.1",
+            "source-map": "^0.4.4",
+            "uglify-js": "^2.6"
           },
           "dependencies": {
             "source-map": {
@@ -9602,7 +11477,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "amdefine": "1.0.1"
+                "amdefine": ">=0.0.4"
               }
             }
           }
@@ -9612,7 +11487,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "ansi-regex": "2.1.1"
+            "ansi-regex": "^2.0.0"
           }
         },
         "has-flag": {
@@ -9625,9 +11500,9 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "get-value": "2.0.6",
-            "has-values": "1.0.0",
-            "isobject": "3.0.1"
+            "get-value": "^2.0.6",
+            "has-values": "^1.0.0",
+            "isobject": "^3.0.0"
           },
           "dependencies": {
             "isobject": {
@@ -9642,8 +11517,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "is-number": "3.0.0",
-            "kind-of": "4.0.0"
+            "is-number": "^3.0.0",
+            "kind-of": "^4.0.0"
           },
           "dependencies": {
             "is-number": {
@@ -9651,7 +11526,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "kind-of": "3.2.2"
+                "kind-of": "^3.0.2"
               },
               "dependencies": {
                 "kind-of": {
@@ -9659,7 +11534,7 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "is-buffer": "1.1.6"
+                    "is-buffer": "^1.1.5"
                   }
                 }
               }
@@ -9669,7 +11544,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "is-buffer": "1.1.6"
+                "is-buffer": "^1.1.5"
               }
             }
           }
@@ -9689,8 +11564,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "once": "1.4.0",
-            "wrappy": "1.0.2"
+            "once": "^1.3.0",
+            "wrappy": "1"
           }
         },
         "inherits": {
@@ -9703,7 +11578,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "loose-envify": "1.3.1"
+            "loose-envify": "^1.0.0"
           }
         },
         "invert-kv": {
@@ -9716,7 +11591,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "kind-of": "3.2.2"
+            "kind-of": "^3.0.2"
           }
         },
         "is-arrayish": {
@@ -9734,7 +11609,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "builtin-modules": "1.1.1"
+            "builtin-modules": "^1.0.0"
           }
         },
         "is-data-descriptor": {
@@ -9742,7 +11617,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "kind-of": "3.2.2"
+            "kind-of": "^3.0.2"
           }
         },
         "is-descriptor": {
@@ -9750,9 +11625,9 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "is-accessor-descriptor": "0.1.6",
-            "is-data-descriptor": "0.1.4",
-            "kind-of": "5.1.0"
+            "is-accessor-descriptor": "^0.1.6",
+            "is-data-descriptor": "^0.1.4",
+            "kind-of": "^5.0.0"
           },
           "dependencies": {
             "kind-of": {
@@ -9772,7 +11647,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "number-is-nan": "1.0.1"
+            "number-is-nan": "^1.0.0"
           }
         },
         "is-fullwidth-code-point": {
@@ -9785,7 +11660,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "kind-of": "3.2.2"
+            "kind-of": "^3.0.2"
           }
         },
         "is-odd": {
@@ -9793,7 +11668,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "is-number": "4.0.0"
+            "is-number": "^4.0.0"
           },
           "dependencies": {
             "is-number": {
@@ -9808,7 +11683,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "isobject": "3.0.1"
+            "isobject": "^3.0.1"
           },
           "dependencies": {
             "isobject": {
@@ -9858,7 +11733,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "append-transform": "0.4.0"
+            "append-transform": "^0.4.0"
           }
         },
         "istanbul-lib-instrument": {
@@ -9866,13 +11741,13 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "babel-generator": "6.26.1",
-            "babel-template": "6.26.0",
-            "babel-traverse": "6.26.0",
-            "babel-types": "6.26.0",
-            "babylon": "6.18.0",
-            "istanbul-lib-coverage": "1.2.0",
-            "semver": "5.5.0"
+            "babel-generator": "^6.18.0",
+            "babel-template": "^6.16.0",
+            "babel-traverse": "^6.18.0",
+            "babel-types": "^6.18.0",
+            "babylon": "^6.18.0",
+            "istanbul-lib-coverage": "^1.2.0",
+            "semver": "^5.3.0"
           }
         },
         "istanbul-lib-report": {
@@ -9880,10 +11755,10 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "istanbul-lib-coverage": "1.2.0",
-            "mkdirp": "0.5.1",
-            "path-parse": "1.0.5",
-            "supports-color": "3.2.3"
+            "istanbul-lib-coverage": "^1.1.2",
+            "mkdirp": "^0.5.1",
+            "path-parse": "^1.0.5",
+            "supports-color": "^3.1.2"
           },
           "dependencies": {
             "supports-color": {
@@ -9891,7 +11766,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "has-flag": "1.0.0"
+                "has-flag": "^1.0.0"
               }
             }
           }
@@ -9901,11 +11776,11 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "debug": "3.1.0",
-            "istanbul-lib-coverage": "1.2.0",
-            "mkdirp": "0.5.1",
-            "rimraf": "2.6.2",
-            "source-map": "0.5.7"
+            "debug": "^3.1.0",
+            "istanbul-lib-coverage": "^1.1.2",
+            "mkdirp": "^0.5.1",
+            "rimraf": "^2.6.1",
+            "source-map": "^0.5.3"
           },
           "dependencies": {
             "debug": {
@@ -9923,7 +11798,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "handlebars": "4.0.11"
+            "handlebars": "^4.0.3"
           }
         },
         "js-tokens": {
@@ -9941,7 +11816,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "is-buffer": "1.1.6"
+            "is-buffer": "^1.1.5"
           }
         },
         "lazy-cache": {
@@ -9955,7 +11830,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "invert-kv": "1.0.0"
+            "invert-kv": "^1.0.0"
           }
         },
         "load-json-file": {
@@ -9963,11 +11838,11 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "graceful-fs": "4.1.11",
-            "parse-json": "2.2.0",
-            "pify": "2.3.0",
-            "pinkie-promise": "2.0.1",
-            "strip-bom": "2.0.0"
+            "graceful-fs": "^4.1.2",
+            "parse-json": "^2.2.0",
+            "pify": "^2.0.0",
+            "pinkie-promise": "^2.0.0",
+            "strip-bom": "^2.0.0"
           }
         },
         "locate-path": {
@@ -9975,8 +11850,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "p-locate": "2.0.0",
-            "path-exists": "3.0.0"
+            "p-locate": "^2.0.0",
+            "path-exists": "^3.0.0"
           },
           "dependencies": {
             "path-exists": {
@@ -10001,7 +11876,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "js-tokens": "3.0.2"
+            "js-tokens": "^3.0.0"
           }
         },
         "lru-cache": {
@@ -10009,8 +11884,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "pseudomap": "1.0.2",
-            "yallist": "2.1.2"
+            "pseudomap": "^1.0.2",
+            "yallist": "^2.1.2"
           }
         },
         "map-cache": {
@@ -10023,7 +11898,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "object-visit": "1.0.1"
+            "object-visit": "^1.0.0"
           }
         },
         "md5-hex": {
@@ -10031,7 +11906,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "md5-o-matic": "0.1.1"
+            "md5-o-matic": "^0.1.1"
           }
         },
         "md5-o-matic": {
@@ -10044,7 +11919,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "mimic-fn": "1.2.0"
+            "mimic-fn": "^1.0.0"
           }
         },
         "merge-source-map": {
@@ -10052,7 +11927,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "source-map": "0.6.1"
+            "source-map": "^0.6.1"
           },
           "dependencies": {
             "source-map": {
@@ -10067,19 +11942,19 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "arr-diff": "4.0.0",
-            "array-unique": "0.3.2",
-            "braces": "2.3.2",
-            "define-property": "2.0.2",
-            "extend-shallow": "3.0.2",
-            "extglob": "2.0.4",
-            "fragment-cache": "0.2.1",
-            "kind-of": "6.0.2",
-            "nanomatch": "1.2.9",
-            "object.pick": "1.3.0",
-            "regex-not": "1.0.2",
-            "snapdragon": "0.8.2",
-            "to-regex": "3.0.2"
+            "arr-diff": "^4.0.0",
+            "array-unique": "^0.3.2",
+            "braces": "^2.3.1",
+            "define-property": "^2.0.2",
+            "extend-shallow": "^3.0.2",
+            "extglob": "^2.0.4",
+            "fragment-cache": "^0.2.1",
+            "kind-of": "^6.0.2",
+            "nanomatch": "^1.2.9",
+            "object.pick": "^1.3.0",
+            "regex-not": "^1.0.0",
+            "snapdragon": "^0.8.1",
+            "to-regex": "^3.0.2"
           },
           "dependencies": {
             "kind-of": {
@@ -10099,7 +11974,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "brace-expansion": "1.1.11"
+            "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
@@ -10112,8 +11987,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "for-in": "1.0.2",
-            "is-extendable": "1.0.1"
+            "for-in": "^1.0.2",
+            "is-extendable": "^1.0.1"
           },
           "dependencies": {
             "is-extendable": {
@@ -10121,7 +11996,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "is-plain-object": "2.0.4"
+                "is-plain-object": "^2.0.4"
               }
             }
           }
@@ -10144,18 +12019,18 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "arr-diff": "4.0.0",
-            "array-unique": "0.3.2",
-            "define-property": "2.0.2",
-            "extend-shallow": "3.0.2",
-            "fragment-cache": "0.2.1",
-            "is-odd": "2.0.0",
-            "is-windows": "1.0.2",
-            "kind-of": "6.0.2",
-            "object.pick": "1.3.0",
-            "regex-not": "1.0.2",
-            "snapdragon": "0.8.2",
-            "to-regex": "3.0.2"
+            "arr-diff": "^4.0.0",
+            "array-unique": "^0.3.2",
+            "define-property": "^2.0.2",
+            "extend-shallow": "^3.0.2",
+            "fragment-cache": "^0.2.1",
+            "is-odd": "^2.0.0",
+            "is-windows": "^1.0.2",
+            "kind-of": "^6.0.2",
+            "object.pick": "^1.3.0",
+            "regex-not": "^1.0.0",
+            "snapdragon": "^0.8.1",
+            "to-regex": "^3.0.1"
           },
           "dependencies": {
             "arr-diff": {
@@ -10180,10 +12055,10 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "hosted-git-info": "2.6.0",
-            "is-builtin-module": "1.0.0",
-            "semver": "5.5.0",
-            "validate-npm-package-license": "3.0.3"
+            "hosted-git-info": "^2.1.4",
+            "is-builtin-module": "^1.0.0",
+            "semver": "2 || 3 || 4 || 5",
+            "validate-npm-package-license": "^3.0.1"
           }
         },
         "npm-run-path": {
@@ -10191,7 +12066,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "path-key": "2.0.1"
+            "path-key": "^2.0.0"
           }
         },
         "number-is-nan": {
@@ -10209,9 +12084,9 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "copy-descriptor": "0.1.1",
-            "define-property": "0.2.5",
-            "kind-of": "3.2.2"
+            "copy-descriptor": "^0.1.0",
+            "define-property": "^0.2.5",
+            "kind-of": "^3.0.3"
           },
           "dependencies": {
             "define-property": {
@@ -10219,7 +12094,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "is-descriptor": "0.1.6"
+                "is-descriptor": "^0.1.0"
               }
             }
           }
@@ -10229,7 +12104,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "isobject": "3.0.1"
+            "isobject": "^3.0.0"
           },
           "dependencies": {
             "isobject": {
@@ -10244,7 +12119,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "isobject": "3.0.1"
+            "isobject": "^3.0.1"
           },
           "dependencies": {
             "isobject": {
@@ -10259,7 +12134,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "wrappy": "1.0.2"
+            "wrappy": "1"
           }
         },
         "optimist": {
@@ -10267,8 +12142,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "minimist": "0.0.8",
-            "wordwrap": "0.0.3"
+            "minimist": "~0.0.1",
+            "wordwrap": "~0.0.2"
           }
         },
         "os-homedir": {
@@ -10281,9 +12156,9 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "execa": "0.7.0",
-            "lcid": "1.0.0",
-            "mem": "1.1.0"
+            "execa": "^0.7.0",
+            "lcid": "^1.0.0",
+            "mem": "^1.1.0"
           }
         },
         "p-finally": {
@@ -10296,7 +12171,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "p-try": "1.0.0"
+            "p-try": "^1.0.0"
           }
         },
         "p-locate": {
@@ -10304,7 +12179,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "p-limit": "1.2.0"
+            "p-limit": "^1.1.0"
           }
         },
         "p-try": {
@@ -10317,7 +12192,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "error-ex": "1.3.1"
+            "error-ex": "^1.2.0"
           }
         },
         "pascalcase": {
@@ -10330,7 +12205,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "pinkie-promise": "2.0.1"
+            "pinkie-promise": "^2.0.0"
           }
         },
         "path-is-absolute": {
@@ -10353,9 +12228,9 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "graceful-fs": "4.1.11",
-            "pify": "2.3.0",
-            "pinkie-promise": "2.0.1"
+            "graceful-fs": "^4.1.2",
+            "pify": "^2.0.0",
+            "pinkie-promise": "^2.0.0"
           }
         },
         "pify": {
@@ -10373,7 +12248,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "pinkie": "2.0.4"
+            "pinkie": "^2.0.0"
           }
         },
         "pkg-dir": {
@@ -10381,7 +12256,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "find-up": "1.1.2"
+            "find-up": "^1.0.0"
           },
           "dependencies": {
             "find-up": {
@@ -10389,8 +12264,8 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "path-exists": "2.1.0",
-                "pinkie-promise": "2.0.1"
+                "path-exists": "^2.0.0",
+                "pinkie-promise": "^2.0.0"
               }
             }
           }
@@ -10410,9 +12285,9 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "load-json-file": "1.1.0",
-            "normalize-package-data": "2.4.0",
-            "path-type": "1.1.0"
+            "load-json-file": "^1.0.0",
+            "normalize-package-data": "^2.3.2",
+            "path-type": "^1.0.0"
           }
         },
         "read-pkg-up": {
@@ -10420,8 +12295,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "find-up": "1.1.2",
-            "read-pkg": "1.1.0"
+            "find-up": "^1.0.0",
+            "read-pkg": "^1.0.0"
           },
           "dependencies": {
             "find-up": {
@@ -10429,8 +12304,8 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "path-exists": "2.1.0",
-                "pinkie-promise": "2.0.1"
+                "path-exists": "^2.0.0",
+                "pinkie-promise": "^2.0.0"
               }
             }
           }
@@ -10445,8 +12320,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "extend-shallow": "3.0.2",
-            "safe-regex": "1.1.0"
+            "extend-shallow": "^3.0.2",
+            "safe-regex": "^1.1.0"
           }
         },
         "repeat-element": {
@@ -10464,7 +12339,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "is-finite": "1.0.2"
+            "is-finite": "^1.0.0"
           }
         },
         "require-directory": {
@@ -10498,7 +12373,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "align-text": "0.1.4"
+            "align-text": "^0.1.1"
           }
         },
         "rimraf": {
@@ -10506,7 +12381,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "glob": "7.1.2"
+            "glob": "^7.0.5"
           }
         },
         "safe-regex": {
@@ -10514,7 +12389,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "ret": "0.1.15"
+            "ret": "~0.1.10"
           }
         },
         "semver": {
@@ -10532,10 +12407,10 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "extend-shallow": "2.0.1",
-            "is-extendable": "0.1.1",
-            "is-plain-object": "2.0.4",
-            "split-string": "3.1.0"
+            "extend-shallow": "^2.0.1",
+            "is-extendable": "^0.1.1",
+            "is-plain-object": "^2.0.3",
+            "split-string": "^3.0.1"
           },
           "dependencies": {
             "extend-shallow": {
@@ -10543,7 +12418,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "is-extendable": "0.1.1"
+                "is-extendable": "^0.1.0"
               }
             }
           }
@@ -10553,7 +12428,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "shebang-regex": "1.0.0"
+            "shebang-regex": "^1.0.0"
           }
         },
         "shebang-regex": {
@@ -10576,14 +12451,14 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "base": "0.11.2",
-            "debug": "2.6.9",
-            "define-property": "0.2.5",
-            "extend-shallow": "2.0.1",
-            "map-cache": "0.2.2",
-            "source-map": "0.5.7",
-            "source-map-resolve": "0.5.1",
-            "use": "3.1.0"
+            "base": "^0.11.1",
+            "debug": "^2.2.0",
+            "define-property": "^0.2.5",
+            "extend-shallow": "^2.0.1",
+            "map-cache": "^0.2.2",
+            "source-map": "^0.5.6",
+            "source-map-resolve": "^0.5.0",
+            "use": "^3.1.0"
           },
           "dependencies": {
             "define-property": {
@@ -10591,7 +12466,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "is-descriptor": "0.1.6"
+                "is-descriptor": "^0.1.0"
               }
             },
             "extend-shallow": {
@@ -10599,7 +12474,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "is-extendable": "0.1.1"
+                "is-extendable": "^0.1.0"
               }
             }
           }
@@ -10609,9 +12484,9 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "define-property": "1.0.0",
-            "isobject": "3.0.1",
-            "snapdragon-util": "3.0.1"
+            "define-property": "^1.0.0",
+            "isobject": "^3.0.0",
+            "snapdragon-util": "^3.0.1"
           },
           "dependencies": {
             "define-property": {
@@ -10619,7 +12494,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "is-descriptor": "1.0.2"
+                "is-descriptor": "^1.0.0"
               }
             },
             "is-accessor-descriptor": {
@@ -10627,7 +12502,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "kind-of": "6.0.2"
+                "kind-of": "^6.0.0"
               }
             },
             "is-data-descriptor": {
@@ -10635,7 +12510,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "kind-of": "6.0.2"
+                "kind-of": "^6.0.0"
               }
             },
             "is-descriptor": {
@@ -10643,9 +12518,9 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "is-accessor-descriptor": "1.0.0",
-                "is-data-descriptor": "1.0.0",
-                "kind-of": "6.0.2"
+                "is-accessor-descriptor": "^1.0.0",
+                "is-data-descriptor": "^1.0.0",
+                "kind-of": "^6.0.2"
               }
             },
             "isobject": {
@@ -10665,7 +12540,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "kind-of": "3.2.2"
+            "kind-of": "^3.2.0"
           }
         },
         "source-map": {
@@ -10678,11 +12553,11 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "atob": "2.1.1",
-            "decode-uri-component": "0.2.0",
-            "resolve-url": "0.2.1",
-            "source-map-url": "0.4.0",
-            "urix": "0.1.0"
+            "atob": "^2.0.0",
+            "decode-uri-component": "^0.2.0",
+            "resolve-url": "^0.2.1",
+            "source-map-url": "^0.4.0",
+            "urix": "^0.1.0"
           }
         },
         "source-map-url": {
@@ -10695,12 +12570,12 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "foreground-child": "1.5.6",
-            "mkdirp": "0.5.1",
-            "os-homedir": "1.0.2",
-            "rimraf": "2.6.2",
-            "signal-exit": "3.0.2",
-            "which": "1.3.0"
+            "foreground-child": "^1.5.6",
+            "mkdirp": "^0.5.0",
+            "os-homedir": "^1.0.1",
+            "rimraf": "^2.6.2",
+            "signal-exit": "^3.0.2",
+            "which": "^1.3.0"
           }
         },
         "spdx-correct": {
@@ -10708,8 +12583,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "spdx-expression-parse": "3.0.0",
-            "spdx-license-ids": "3.0.0"
+            "spdx-expression-parse": "^3.0.0",
+            "spdx-license-ids": "^3.0.0"
           }
         },
         "spdx-exceptions": {
@@ -10722,8 +12597,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "spdx-exceptions": "2.1.0",
-            "spdx-license-ids": "3.0.0"
+            "spdx-exceptions": "^2.1.0",
+            "spdx-license-ids": "^3.0.0"
           }
         },
         "spdx-license-ids": {
@@ -10736,7 +12611,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "extend-shallow": "3.0.2"
+            "extend-shallow": "^3.0.0"
           }
         },
         "static-extend": {
@@ -10744,8 +12619,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "define-property": "0.2.5",
-            "object-copy": "0.1.0"
+            "define-property": "^0.2.5",
+            "object-copy": "^0.1.0"
           },
           "dependencies": {
             "define-property": {
@@ -10753,7 +12628,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "is-descriptor": "0.1.6"
+                "is-descriptor": "^0.1.0"
               }
             }
           }
@@ -10763,8 +12638,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "is-fullwidth-code-point": "2.0.0",
-            "strip-ansi": "4.0.0"
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^4.0.0"
           },
           "dependencies": {
             "ansi-regex": {
@@ -10777,7 +12652,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "ansi-regex": "3.0.0"
+                "ansi-regex": "^3.0.0"
               }
             }
           }
@@ -10787,7 +12662,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "ansi-regex": "2.1.1"
+            "ansi-regex": "^2.0.0"
           }
         },
         "strip-bom": {
@@ -10795,7 +12670,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "is-utf8": "0.2.1"
+            "is-utf8": "^0.2.0"
           }
         },
         "strip-eof": {
@@ -10813,11 +12688,11 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "arrify": "1.0.1",
-            "micromatch": "3.1.10",
-            "object-assign": "4.1.1",
-            "read-pkg-up": "1.0.1",
-            "require-main-filename": "1.0.1"
+            "arrify": "^1.0.1",
+            "micromatch": "^3.1.8",
+            "object-assign": "^4.1.0",
+            "read-pkg-up": "^1.0.1",
+            "require-main-filename": "^1.0.1"
           },
           "dependencies": {
             "arr-diff": {
@@ -10835,16 +12710,16 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "arr-flatten": "1.1.0",
-                "array-unique": "0.3.2",
-                "extend-shallow": "2.0.1",
-                "fill-range": "4.0.0",
-                "isobject": "3.0.1",
-                "repeat-element": "1.1.2",
-                "snapdragon": "0.8.2",
-                "snapdragon-node": "2.1.1",
-                "split-string": "3.1.0",
-                "to-regex": "3.0.2"
+                "arr-flatten": "^1.1.0",
+                "array-unique": "^0.3.2",
+                "extend-shallow": "^2.0.1",
+                "fill-range": "^4.0.0",
+                "isobject": "^3.0.1",
+                "repeat-element": "^1.1.2",
+                "snapdragon": "^0.8.1",
+                "snapdragon-node": "^2.0.1",
+                "split-string": "^3.0.2",
+                "to-regex": "^3.0.1"
               },
               "dependencies": {
                 "extend-shallow": {
@@ -10852,7 +12727,7 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "is-extendable": "0.1.1"
+                    "is-extendable": "^0.1.0"
                   }
                 }
               }
@@ -10862,13 +12737,13 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "debug": "2.6.9",
-                "define-property": "0.2.5",
-                "extend-shallow": "2.0.1",
-                "posix-character-classes": "0.1.1",
-                "regex-not": "1.0.2",
-                "snapdragon": "0.8.2",
-                "to-regex": "3.0.2"
+                "debug": "^2.3.3",
+                "define-property": "^0.2.5",
+                "extend-shallow": "^2.0.1",
+                "posix-character-classes": "^0.1.0",
+                "regex-not": "^1.0.0",
+                "snapdragon": "^0.8.1",
+                "to-regex": "^3.0.1"
               },
               "dependencies": {
                 "define-property": {
@@ -10876,7 +12751,7 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "is-descriptor": "0.1.6"
+                    "is-descriptor": "^0.1.0"
                   }
                 },
                 "extend-shallow": {
@@ -10884,7 +12759,7 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "is-extendable": "0.1.1"
+                    "is-extendable": "^0.1.0"
                   }
                 },
                 "is-accessor-descriptor": {
@@ -10892,7 +12767,7 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "kind-of": "3.2.2"
+                    "kind-of": "^3.0.2"
                   },
                   "dependencies": {
                     "kind-of": {
@@ -10900,7 +12775,7 @@
                       "bundled": true,
                       "dev": true,
                       "requires": {
-                        "is-buffer": "1.1.6"
+                        "is-buffer": "^1.1.5"
                       }
                     }
                   }
@@ -10910,7 +12785,7 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "kind-of": "3.2.2"
+                    "kind-of": "^3.0.2"
                   },
                   "dependencies": {
                     "kind-of": {
@@ -10918,7 +12793,7 @@
                       "bundled": true,
                       "dev": true,
                       "requires": {
-                        "is-buffer": "1.1.6"
+                        "is-buffer": "^1.1.5"
                       }
                     }
                   }
@@ -10928,9 +12803,9 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "is-accessor-descriptor": "0.1.6",
-                    "is-data-descriptor": "0.1.4",
-                    "kind-of": "5.1.0"
+                    "is-accessor-descriptor": "^0.1.6",
+                    "is-data-descriptor": "^0.1.4",
+                    "kind-of": "^5.0.0"
                   }
                 },
                 "kind-of": {
@@ -10945,14 +12820,14 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "array-unique": "0.3.2",
-                "define-property": "1.0.0",
-                "expand-brackets": "2.1.4",
-                "extend-shallow": "2.0.1",
-                "fragment-cache": "0.2.1",
-                "regex-not": "1.0.2",
-                "snapdragon": "0.8.2",
-                "to-regex": "3.0.2"
+                "array-unique": "^0.3.2",
+                "define-property": "^1.0.0",
+                "expand-brackets": "^2.1.4",
+                "extend-shallow": "^2.0.1",
+                "fragment-cache": "^0.2.1",
+                "regex-not": "^1.0.0",
+                "snapdragon": "^0.8.1",
+                "to-regex": "^3.0.1"
               },
               "dependencies": {
                 "define-property": {
@@ -10960,7 +12835,7 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "is-descriptor": "1.0.2"
+                    "is-descriptor": "^1.0.0"
                   }
                 },
                 "extend-shallow": {
@@ -10968,7 +12843,7 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "is-extendable": "0.1.1"
+                    "is-extendable": "^0.1.0"
                   }
                 }
               }
@@ -10978,10 +12853,10 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "extend-shallow": "2.0.1",
-                "is-number": "3.0.0",
-                "repeat-string": "1.6.1",
-                "to-regex-range": "2.1.1"
+                "extend-shallow": "^2.0.1",
+                "is-number": "^3.0.0",
+                "repeat-string": "^1.6.1",
+                "to-regex-range": "^2.1.0"
               },
               "dependencies": {
                 "extend-shallow": {
@@ -10989,7 +12864,7 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "is-extendable": "0.1.1"
+                    "is-extendable": "^0.1.0"
                   }
                 }
               }
@@ -10999,7 +12874,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "kind-of": "6.0.2"
+                "kind-of": "^6.0.0"
               }
             },
             "is-data-descriptor": {
@@ -11007,7 +12882,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "kind-of": "6.0.2"
+                "kind-of": "^6.0.0"
               }
             },
             "is-descriptor": {
@@ -11015,9 +12890,9 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "is-accessor-descriptor": "1.0.0",
-                "is-data-descriptor": "1.0.0",
-                "kind-of": "6.0.2"
+                "is-accessor-descriptor": "^1.0.0",
+                "is-data-descriptor": "^1.0.0",
+                "kind-of": "^6.0.2"
               }
             },
             "is-number": {
@@ -11025,7 +12900,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "kind-of": "3.2.2"
+                "kind-of": "^3.0.2"
               },
               "dependencies": {
                 "kind-of": {
@@ -11033,7 +12908,7 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "is-buffer": "1.1.6"
+                    "is-buffer": "^1.1.5"
                   }
                 }
               }
@@ -11053,19 +12928,19 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "arr-diff": "4.0.0",
-                "array-unique": "0.3.2",
-                "braces": "2.3.2",
-                "define-property": "2.0.2",
-                "extend-shallow": "3.0.2",
-                "extglob": "2.0.4",
-                "fragment-cache": "0.2.1",
-                "kind-of": "6.0.2",
-                "nanomatch": "1.2.9",
-                "object.pick": "1.3.0",
-                "regex-not": "1.0.2",
-                "snapdragon": "0.8.2",
-                "to-regex": "3.0.2"
+                "arr-diff": "^4.0.0",
+                "array-unique": "^0.3.2",
+                "braces": "^2.3.1",
+                "define-property": "^2.0.2",
+                "extend-shallow": "^3.0.2",
+                "extglob": "^2.0.4",
+                "fragment-cache": "^0.2.1",
+                "kind-of": "^6.0.2",
+                "nanomatch": "^1.2.9",
+                "object.pick": "^1.3.0",
+                "regex-not": "^1.0.0",
+                "snapdragon": "^0.8.1",
+                "to-regex": "^3.0.2"
               }
             }
           }
@@ -11080,7 +12955,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "kind-of": "3.2.2"
+            "kind-of": "^3.0.2"
           }
         },
         "to-regex": {
@@ -11088,10 +12963,10 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "define-property": "2.0.2",
-            "extend-shallow": "3.0.2",
-            "regex-not": "1.0.2",
-            "safe-regex": "1.1.0"
+            "define-property": "^2.0.2",
+            "extend-shallow": "^3.0.2",
+            "regex-not": "^1.0.2",
+            "safe-regex": "^1.1.0"
           }
         },
         "to-regex-range": {
@@ -11099,8 +12974,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "is-number": "3.0.0",
-            "repeat-string": "1.6.1"
+            "is-number": "^3.0.0",
+            "repeat-string": "^1.6.1"
           },
           "dependencies": {
             "is-number": {
@@ -11108,7 +12983,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "kind-of": "3.2.2"
+                "kind-of": "^3.0.2"
               }
             }
           }
@@ -11124,9 +12999,9 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "source-map": "0.5.7",
-            "uglify-to-browserify": "1.0.2",
-            "yargs": "3.10.0"
+            "source-map": "~0.5.1",
+            "uglify-to-browserify": "~1.0.0",
+            "yargs": "~3.10.0"
           },
           "dependencies": {
             "yargs": {
@@ -11135,9 +13010,9 @@
               "dev": true,
               "optional": true,
               "requires": {
-                "camelcase": "1.2.1",
-                "cliui": "2.1.0",
-                "decamelize": "1.2.0",
+                "camelcase": "^1.0.2",
+                "cliui": "^2.1.0",
+                "decamelize": "^1.0.0",
                 "window-size": "0.1.0"
               }
             }
@@ -11154,10 +13029,10 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "arr-union": "3.1.0",
-            "get-value": "2.0.6",
-            "is-extendable": "0.1.1",
-            "set-value": "0.4.3"
+            "arr-union": "^3.1.0",
+            "get-value": "^2.0.6",
+            "is-extendable": "^0.1.1",
+            "set-value": "^0.4.3"
           },
           "dependencies": {
             "extend-shallow": {
@@ -11165,7 +13040,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "is-extendable": "0.1.1"
+                "is-extendable": "^0.1.0"
               }
             },
             "set-value": {
@@ -11173,10 +13048,10 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "extend-shallow": "2.0.1",
-                "is-extendable": "0.1.1",
-                "is-plain-object": "2.0.4",
-                "to-object-path": "0.3.0"
+                "extend-shallow": "^2.0.1",
+                "is-extendable": "^0.1.1",
+                "is-plain-object": "^2.0.1",
+                "to-object-path": "^0.3.0"
               }
             }
           }
@@ -11186,8 +13061,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "has-value": "0.3.1",
-            "isobject": "3.0.1"
+            "has-value": "^0.3.1",
+            "isobject": "^3.0.0"
           },
           "dependencies": {
             "has-value": {
@@ -11195,9 +13070,9 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "get-value": "2.0.6",
-                "has-values": "0.1.4",
-                "isobject": "2.1.0"
+                "get-value": "^2.0.3",
+                "has-values": "^0.1.4",
+                "isobject": "^2.0.0"
               },
               "dependencies": {
                 "isobject": {
@@ -11232,7 +13107,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "kind-of": "6.0.2"
+            "kind-of": "^6.0.2"
           },
           "dependencies": {
             "kind-of": {
@@ -11247,8 +13122,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "spdx-correct": "3.0.0",
-            "spdx-expression-parse": "3.0.0"
+            "spdx-correct": "^3.0.0",
+            "spdx-expression-parse": "^3.0.0"
           }
         },
         "which": {
@@ -11256,7 +13131,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "isexe": "2.0.0"
+            "isexe": "^2.0.0"
           }
         },
         "which-module": {
@@ -11280,8 +13155,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "string-width": "1.0.2",
-            "strip-ansi": "3.0.1"
+            "string-width": "^1.0.1",
+            "strip-ansi": "^3.0.1"
           },
           "dependencies": {
             "is-fullwidth-code-point": {
@@ -11289,7 +13164,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "number-is-nan": "1.0.1"
+                "number-is-nan": "^1.0.0"
               }
             },
             "string-width": {
@@ -11297,9 +13172,9 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "code-point-at": "1.1.0",
-                "is-fullwidth-code-point": "1.0.0",
-                "strip-ansi": "3.0.1"
+                "code-point-at": "^1.0.0",
+                "is-fullwidth-code-point": "^1.0.0",
+                "strip-ansi": "^3.0.0"
               }
             }
           }
@@ -11314,9 +13189,9 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "graceful-fs": "4.1.11",
-            "imurmurhash": "0.1.4",
-            "slide": "1.1.6"
+            "graceful-fs": "^4.1.11",
+            "imurmurhash": "^0.1.4",
+            "slide": "^1.1.5"
           }
         },
         "y18n": {
@@ -11334,18 +13209,18 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "cliui": "4.1.0",
-            "decamelize": "1.2.0",
-            "find-up": "2.1.0",
-            "get-caller-file": "1.0.2",
-            "os-locale": "2.1.0",
-            "require-directory": "2.1.1",
-            "require-main-filename": "1.0.1",
-            "set-blocking": "2.0.0",
-            "string-width": "2.1.1",
-            "which-module": "2.0.0",
-            "y18n": "3.2.1",
-            "yargs-parser": "9.0.2"
+            "cliui": "^4.0.0",
+            "decamelize": "^1.1.1",
+            "find-up": "^2.1.0",
+            "get-caller-file": "^1.0.1",
+            "os-locale": "^2.0.0",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^1.0.1",
+            "set-blocking": "^2.0.0",
+            "string-width": "^2.0.0",
+            "which-module": "^2.0.0",
+            "y18n": "^3.2.1",
+            "yargs-parser": "^9.0.2"
           },
           "dependencies": {
             "ansi-regex": {
@@ -11363,9 +13238,9 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "string-width": "2.1.1",
-                "strip-ansi": "4.0.0",
-                "wrap-ansi": "2.1.0"
+                "string-width": "^2.1.1",
+                "strip-ansi": "^4.0.0",
+                "wrap-ansi": "^2.0.0"
               }
             },
             "strip-ansi": {
@@ -11373,7 +13248,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "ansi-regex": "3.0.0"
+                "ansi-regex": "^3.0.0"
               }
             },
             "yargs-parser": {
@@ -11381,7 +13256,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "camelcase": "4.1.0"
+                "camelcase": "^4.1.0"
               }
             }
           }
@@ -11391,7 +13266,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "camelcase": "4.1.0"
+            "camelcase": "^4.1.0"
           },
           "dependencies": {
             "camelcase": {
@@ -11418,9 +13293,9 @@
       "resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
       "integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
       "requires": {
-        "copy-descriptor": "0.1.1",
-        "define-property": "0.2.5",
-        "kind-of": "3.2.2"
+        "copy-descriptor": "^0.1.0",
+        "define-property": "^0.2.5",
+        "kind-of": "^3.0.3"
       },
       "dependencies": {
         "define-property": {
@@ -11428,7 +13303,7 @@
           "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "requires": {
-            "is-descriptor": "0.1.6"
+            "is-descriptor": "^0.1.0"
           }
         }
       }
@@ -11438,7 +13313,7 @@
       "resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
       "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
       "requires": {
-        "isobject": "3.0.1"
+        "isobject": "^3.0.0"
       }
     },
     "object.pick": {
@@ -11446,7 +13321,7 @@
       "resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
       "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
       "requires": {
-        "isobject": "3.0.1"
+        "isobject": "^3.0.1"
       }
     },
     "once": {
@@ -11454,12 +13329,12 @@
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "requires": {
-        "wrappy": "1.0.2"
+        "wrappy": "1"
       }
     },
     "onetime": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
       "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k="
     },
     "optimist": {
@@ -11467,8 +13342,8 @@
       "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
       "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
       "requires": {
-        "minimist": "0.0.10",
-        "wordwrap": "0.0.3"
+        "minimist": "~0.0.1",
+        "wordwrap": "~0.0.2"
       }
     },
     "optionator": {
@@ -11477,12 +13352,12 @@
       "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
       "dev": true,
       "requires": {
-        "deep-is": "0.1.3",
-        "fast-levenshtein": "2.0.6",
-        "levn": "0.3.0",
-        "prelude-ls": "1.1.2",
-        "type-check": "0.3.2",
-        "wordwrap": "1.0.0"
+        "deep-is": "~0.1.3",
+        "fast-levenshtein": "~2.0.4",
+        "levn": "~0.3.0",
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2",
+        "wordwrap": "~1.0.0"
       },
       "dependencies": {
         "wordwrap": {
@@ -11503,9 +13378,9 @@
       "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
       "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
       "requires": {
-        "execa": "0.7.0",
-        "lcid": "1.0.0",
-        "mem": "1.1.0"
+        "execa": "^0.7.0",
+        "lcid": "^1.0.0",
+        "mem": "^1.1.0"
       }
     },
     "os-shim": {
@@ -11543,7 +13418,7 @@
       "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
       "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
       "requires": {
-        "p-limit": "1.1.0"
+        "p-limit": "^1.1.0"
       }
     },
     "p-timeout": {
@@ -11551,7 +13426,7 @@
       "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-1.2.1.tgz",
       "integrity": "sha1-XrOzU7f86Z8QGhA4iAuwVOu+o4Y=",
       "requires": {
-        "p-finally": "1.0.0"
+        "p-finally": "^1.0.0"
       }
     },
     "parse-github-repo-url": {
@@ -11564,7 +13439,7 @@
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
       "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
       "requires": {
-        "error-ex": "1.3.1"
+        "error-ex": "^1.2.0"
       }
     },
     "pascalcase": {
@@ -11623,7 +13498,7 @@
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
       "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
       "requires": {
-        "pify": "2.3.0"
+        "pify": "^2.0.0"
       }
     },
     "performance-now": {
@@ -11646,7 +13521,7 @@
       "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
       "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
       "requires": {
-        "pinkie": "2.0.4"
+        "pinkie": "^2.0.0"
       }
     },
     "pluralize": {
@@ -11697,10 +13572,10 @@
       "resolved": "https://registry.npmjs.org/pullstream/-/pullstream-0.4.1.tgz",
       "integrity": "sha1-1vs79a7Wl+gxFQ6xACwlo/iuExQ=",
       "requires": {
-        "over": "0.0.5",
-        "readable-stream": "1.0.34",
-        "setimmediate": "1.0.5",
-        "slice-stream": "1.0.0"
+        "over": ">= 0.0.5 < 1",
+        "readable-stream": "~1.0.31",
+        "setimmediate": ">= 1.0.2 < 2",
+        "slice-stream": ">= 1.0.0 < 2"
       },
       "dependencies": {
         "isarray": {
@@ -11713,10 +13588,10 @@
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
             "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
+            "string_decoder": "~0.10.x"
           }
         },
         "string_decoder": {
@@ -11737,17 +13612,22 @@
       "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc="
     },
     "qs": {
-      "version": "6.5.1",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
-      "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A=="
+      "version": "6.5.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
+      "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
+    },
+    "quick-lru": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-1.1.0.tgz",
+      "integrity": "sha1-Q2CxfGETatOAeDl/8RQW4Ybc+7g="
     },
     "read-chunk": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/read-chunk/-/read-chunk-2.1.0.tgz",
       "integrity": "sha1-agTAkoAF7Z1C4aasVgDhnLx/9lU=",
       "requires": {
-        "pify": "3.0.0",
-        "safe-buffer": "5.1.1"
+        "pify": "^3.0.0",
+        "safe-buffer": "^5.1.1"
       },
       "dependencies": {
         "pify": {
@@ -11762,9 +13642,9 @@
       "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
       "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
       "requires": {
-        "load-json-file": "2.0.0",
-        "normalize-package-data": "2.4.0",
-        "path-type": "2.0.0"
+        "load-json-file": "^2.0.0",
+        "normalize-package-data": "^2.3.2",
+        "path-type": "^2.0.0"
       }
     },
     "read-pkg-up": {
@@ -11772,8 +13652,8 @@
       "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
       "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
       "requires": {
-        "find-up": "2.1.0",
-        "read-pkg": "2.0.0"
+        "find-up": "^2.0.0",
+        "read-pkg": "^2.0.0"
       }
     },
     "readable-stream": {
@@ -11781,13 +13661,13 @@
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
       "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
       "requires": {
-        "core-util-is": "1.0.2",
-        "inherits": "2.0.3",
-        "isarray": "1.0.0",
-        "process-nextick-args": "1.0.7",
-        "safe-buffer": "5.1.1",
-        "string_decoder": "1.0.3",
-        "util-deprecate": "1.0.2"
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~1.0.6",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.0.3",
+        "util-deprecate": "~1.0.1"
       }
     },
     "rechoir": {
@@ -11795,7 +13675,7 @@
       "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
       "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
       "requires": {
-        "resolve": "1.5.0"
+        "resolve": "^1.1.6"
       }
     },
     "redent": {
@@ -11803,8 +13683,8 @@
       "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
       "integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
       "requires": {
-        "indent-string": "2.1.0",
-        "strip-indent": "1.0.1"
+        "indent-string": "^2.1.0",
+        "strip-indent": "^1.0.1"
       }
     },
     "regex-not": {
@@ -11812,8 +13692,8 @@
       "resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
       "integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
       "requires": {
-        "extend-shallow": "3.0.2",
-        "safe-regex": "1.1.0"
+        "extend-shallow": "^3.0.2",
+        "safe-regex": "^1.1.0"
       }
     },
     "regexpp": {
@@ -11842,7 +13722,7 @@
       "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
       "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
       "requires": {
-        "is-finite": "1.0.2"
+        "is-finite": "^1.0.0"
       }
     },
     "replace-ext": {
@@ -11851,32 +13731,30 @@
       "integrity": "sha1-3mMSg3P8v3w8z6TeWkgMRaZ5WOs="
     },
     "request": {
-      "version": "2.83.0",
-      "resolved": "https://registry.npmjs.org/request/-/request-2.83.0.tgz",
-      "integrity": "sha512-lR3gD69osqm6EYLk9wB/G1W/laGWjzH90t1vEa2xuxHD5KUrSzp9pUSfTm+YC5Nxt2T8nMPEvKlhbQayU7bgFw==",
+      "version": "2.87.0",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.87.0.tgz",
+      "integrity": "sha512-fcogkm7Az5bsS6Sl0sibkbhcKsnyon/jV1kF3ajGmF0c8HrttdKTPRT9hieOaQHA5HEq6r8OyWOo/o781C1tNw==",
       "requires": {
-        "aws-sign2": "0.7.0",
-        "aws4": "1.6.0",
-        "caseless": "0.12.0",
-        "combined-stream": "1.0.5",
-        "extend": "3.0.1",
-        "forever-agent": "0.6.1",
-        "form-data": "2.3.1",
-        "har-validator": "5.0.3",
-        "hawk": "6.0.2",
-        "http-signature": "1.2.0",
-        "is-typedarray": "1.0.0",
-        "isstream": "0.1.2",
-        "json-stringify-safe": "5.0.1",
-        "mime-types": "2.1.17",
-        "oauth-sign": "0.8.2",
-        "performance-now": "2.1.0",
-        "qs": "6.5.1",
-        "safe-buffer": "5.1.1",
-        "stringstream": "0.0.5",
-        "tough-cookie": "2.3.3",
-        "tunnel-agent": "0.6.0",
-        "uuid": "3.1.0"
+        "aws-sign2": "~0.7.0",
+        "aws4": "^1.6.0",
+        "caseless": "~0.12.0",
+        "combined-stream": "~1.0.5",
+        "extend": "~3.0.1",
+        "forever-agent": "~0.6.1",
+        "form-data": "~2.3.1",
+        "har-validator": "~5.0.3",
+        "http-signature": "~1.2.0",
+        "is-typedarray": "~1.0.0",
+        "isstream": "~0.1.2",
+        "json-stringify-safe": "~5.0.1",
+        "mime-types": "~2.1.17",
+        "oauth-sign": "~0.8.2",
+        "performance-now": "^2.1.0",
+        "qs": "~6.5.1",
+        "safe-buffer": "^5.1.1",
+        "tough-cookie": "~2.3.3",
+        "tunnel-agent": "^0.6.0",
+        "uuid": "^3.1.0"
       }
     },
     "require-directory": {
@@ -11895,8 +13773,8 @@
       "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
       "dev": true,
       "requires": {
-        "caller-path": "0.1.0",
-        "resolve-from": "1.0.1"
+        "caller-path": "^0.1.0",
+        "resolve-from": "^1.0.0"
       }
     },
     "resolve": {
@@ -11904,7 +13782,7 @@
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.5.0.tgz",
       "integrity": "sha512-hgoSGrc3pjzAPHNBg+KnFcK2HwlHTs/YrAGUr6qgTVUZmXv1UEXXl0bZNBKMA9fud6lRYFdPGz0xXxycPzmmiw==",
       "requires": {
-        "path-parse": "1.0.5"
+        "path-parse": "^1.0.5"
       }
     },
     "resolve-from": {
@@ -11923,8 +13801,8 @@
       "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
       "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
       "requires": {
-        "exit-hook": "1.1.1",
-        "onetime": "1.1.0"
+        "exit-hook": "^1.0.0",
+        "onetime": "^1.0.0"
       }
     },
     "ret": {
@@ -11938,7 +13816,7 @@
       "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
       "optional": true,
       "requires": {
-        "align-text": "0.1.4"
+        "align-text": "^0.1.1"
       }
     },
     "rimraf": {
@@ -11946,7 +13824,7 @@
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
       "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
       "requires": {
-        "glob": "7.1.2"
+        "glob": "^7.0.5"
       }
     },
     "run-async": {
@@ -11954,7 +13832,7 @@
       "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
       "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
       "requires": {
-        "is-promise": "2.1.0"
+        "is-promise": "^2.1.0"
       }
     },
     "rx": {
@@ -11974,7 +13852,7 @@
       "integrity": "sha1-dTuHqJoRyVRnxKwWJsTvxOBcZ74=",
       "dev": true,
       "requires": {
-        "rx-lite": "4.0.8"
+        "rx-lite": "*"
       }
     },
     "rxjs": {
@@ -11995,7 +13873,7 @@
       "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
       "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
       "requires": {
-        "ret": "0.1.15"
+        "ret": "~0.1.10"
       }
     },
     "samsam": {
@@ -12023,10 +13901,10 @@
       "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.0.tgz",
       "integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
       "requires": {
-        "extend-shallow": "2.0.1",
-        "is-extendable": "0.1.1",
-        "is-plain-object": "2.0.4",
-        "split-string": "3.1.0"
+        "extend-shallow": "^2.0.1",
+        "is-extendable": "^0.1.1",
+        "is-plain-object": "^2.0.3",
+        "split-string": "^3.0.1"
       },
       "dependencies": {
         "extend-shallow": {
@@ -12034,7 +13912,7 @@
           "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "requires": {
-            "is-extendable": "0.1.1"
+            "is-extendable": "^0.1.0"
           }
         }
       }
@@ -12049,7 +13927,7 @@
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
       "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
       "requires": {
-        "shebang-regex": "1.0.0"
+        "shebang-regex": "^1.0.0"
       }
     },
     "shebang-regex": {
@@ -12062,9 +13940,9 @@
       "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.7.8.tgz",
       "integrity": "sha1-3svPh0sNHl+3LhSxZKloMEjprLM=",
       "requires": {
-        "glob": "7.1.2",
-        "interpret": "1.1.0",
-        "rechoir": "0.6.2"
+        "glob": "^7.0.0",
+        "interpret": "^1.0.0",
+        "rechoir": "^0.6.2"
       }
     },
     "signal-exit": {
@@ -12077,13 +13955,13 @@
       "resolved": "https://registry.npmjs.org/sinon/-/sinon-5.0.7.tgz",
       "integrity": "sha512-GvNLrwpvLZ8jIMZBUhHGUZDq5wlUdceJWyHvZDmqBxnjazpxY1L0FNbGBX6VpcOEoQ8Q4XMWFzm2myJMvx+VjA==",
       "requires": {
-        "@sinonjs/formatio": "2.0.0",
-        "diff": "3.5.0",
-        "lodash.get": "4.4.2",
-        "lolex": "2.6.0",
-        "nise": "1.3.3",
-        "supports-color": "5.4.0",
-        "type-detect": "4.0.8"
+        "@sinonjs/formatio": "^2.0.0",
+        "diff": "^3.1.0",
+        "lodash.get": "^4.4.2",
+        "lolex": "^2.2.0",
+        "nise": "^1.2.0",
+        "supports-color": "^5.1.0",
+        "type-detect": "^4.0.5"
       },
       "dependencies": {
         "diff": {
@@ -12096,7 +13974,7 @@
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
           "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
           "requires": {
-            "has-flag": "3.0.0"
+            "has-flag": "^3.0.0"
           }
         }
       }
@@ -12112,7 +13990,7 @@
       "integrity": "sha512-POqxBK6Lb3q6s047D/XsDVNPnF9Dl8JSaqe9h9lURl0OdNqy/ujDrOiIHtsqXMGbWWTIomRzAMaTyawAU//Reg==",
       "dev": true,
       "requires": {
-        "is-fullwidth-code-point": "2.0.0"
+        "is-fullwidth-code-point": "^2.0.0"
       },
       "dependencies": {
         "is-fullwidth-code-point": {
@@ -12128,7 +14006,7 @@
       "resolved": "https://registry.npmjs.org/slice-stream/-/slice-stream-1.0.0.tgz",
       "integrity": "sha1-WzO9ZvATsaf4ZGCwPUY97DmtPqA=",
       "requires": {
-        "readable-stream": "1.0.34"
+        "readable-stream": "~1.0.31"
       },
       "dependencies": {
         "isarray": {
@@ -12141,10 +14019,10 @@
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
             "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
+            "string_decoder": "~0.10.x"
           }
         },
         "string_decoder": {
@@ -12159,14 +14037,14 @@
       "resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
       "integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
       "requires": {
-        "base": "0.11.2",
-        "debug": "2.6.9",
-        "define-property": "0.2.5",
-        "extend-shallow": "2.0.1",
-        "map-cache": "0.2.2",
-        "source-map": "0.5.7",
-        "source-map-resolve": "0.5.2",
-        "use": "3.1.0"
+        "base": "^0.11.1",
+        "debug": "^2.2.0",
+        "define-property": "^0.2.5",
+        "extend-shallow": "^2.0.1",
+        "map-cache": "^0.2.2",
+        "source-map": "^0.5.6",
+        "source-map-resolve": "^0.5.0",
+        "use": "^3.1.0"
       },
       "dependencies": {
         "define-property": {
@@ -12174,7 +14052,7 @@
           "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "requires": {
-            "is-descriptor": "0.1.6"
+            "is-descriptor": "^0.1.0"
           }
         },
         "extend-shallow": {
@@ -12182,7 +14060,7 @@
           "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "requires": {
-            "is-extendable": "0.1.1"
+            "is-extendable": "^0.1.0"
           }
         },
         "source-map": {
@@ -12197,9 +14075,9 @@
       "resolved": "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
       "integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
       "requires": {
-        "define-property": "1.0.0",
-        "isobject": "3.0.1",
-        "snapdragon-util": "3.0.1"
+        "define-property": "^1.0.0",
+        "isobject": "^3.0.0",
+        "snapdragon-util": "^3.0.1"
       },
       "dependencies": {
         "define-property": {
@@ -12207,7 +14085,7 @@
           "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
           "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
           "requires": {
-            "is-descriptor": "1.0.2"
+            "is-descriptor": "^1.0.0"
           }
         },
         "is-accessor-descriptor": {
@@ -12215,7 +14093,7 @@
           "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
           "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
           "requires": {
-            "kind-of": "6.0.2"
+            "kind-of": "^6.0.0"
           }
         },
         "is-data-descriptor": {
@@ -12223,7 +14101,7 @@
           "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
           "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
           "requires": {
-            "kind-of": "6.0.2"
+            "kind-of": "^6.0.0"
           }
         },
         "is-descriptor": {
@@ -12231,9 +14109,9 @@
           "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
           "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
           "requires": {
-            "is-accessor-descriptor": "1.0.0",
-            "is-data-descriptor": "1.0.0",
-            "kind-of": "6.0.2"
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
           }
         },
         "kind-of": {
@@ -12248,15 +14126,7 @@
       "resolved": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
       "integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
       "requires": {
-        "kind-of": "3.2.2"
-      }
-    },
-    "sntp": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/sntp/-/sntp-2.1.0.tgz",
-      "integrity": "sha512-FL1b58BDrqS3A11lJ0zEdnJ3UOKqVxawAkF3k7F0CVN7VQ34aZrV+G8BZ1WC9ZL7NyrwsW0oviwsWDgRuVYtJg==",
-      "requires": {
-        "hoek": "4.2.0"
+        "kind-of": "^3.2.0"
       }
     },
     "source-map": {
@@ -12264,7 +14134,7 @@
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
       "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
       "requires": {
-        "amdefine": "1.0.1"
+        "amdefine": ">=0.0.4"
       }
     },
     "source-map-resolve": {
@@ -12272,11 +14142,11 @@
       "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.2.tgz",
       "integrity": "sha512-MjqsvNwyz1s0k81Goz/9vRBe9SZdB09Bdw+/zYyO+3CuPk6fouTaxscHkgtE8jKvf01kVfl8riHzERQ/kefaSA==",
       "requires": {
-        "atob": "2.1.1",
-        "decode-uri-component": "0.2.0",
-        "resolve-url": "0.2.1",
-        "source-map-url": "0.4.0",
-        "urix": "0.1.0"
+        "atob": "^2.1.1",
+        "decode-uri-component": "^0.2.0",
+        "resolve-url": "^0.2.1",
+        "source-map-url": "^0.4.0",
+        "urix": "^0.1.0"
       }
     },
     "source-map-url": {
@@ -12289,8 +14159,8 @@
       "resolved": "https://registry.npmjs.org/spawn-sync/-/spawn-sync-1.0.15.tgz",
       "integrity": "sha1-sAeZVX63+wyDdsKdROih6mfldHY=",
       "requires": {
-        "concat-stream": "1.6.0",
-        "os-shim": "0.1.3"
+        "concat-stream": "^1.4.7",
+        "os-shim": "^0.1.2"
       }
     },
     "spdx-correct": {
@@ -12298,7 +14168,7 @@
       "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
       "integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
       "requires": {
-        "spdx-license-ids": "1.2.2"
+        "spdx-license-ids": "^1.0.2"
       }
     },
     "spdx-expression-parse": {
@@ -12316,7 +14186,7 @@
       "resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
       "integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
       "requires": {
-        "through": "2.3.8"
+        "through": "2"
       }
     },
     "split-string": {
@@ -12324,7 +14194,7 @@
       "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
       "integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
       "requires": {
-        "extend-shallow": "3.0.2"
+        "extend-shallow": "^3.0.0"
       }
     },
     "split2": {
@@ -12332,7 +14202,7 @@
       "resolved": "https://registry.npmjs.org/split2/-/split2-2.2.0.tgz",
       "integrity": "sha512-RAb22TG39LhI31MbreBgIuKiIKhVsawfTgEGqKHTK87aG+ul/PB8Sqoi3I7kVdRWiCfrKxK3uo4/YUkpNvhPbw==",
       "requires": {
-        "through2": "2.0.3"
+        "through2": "^2.0.2"
       }
     },
     "sprintf-js": {
@@ -12341,33 +14211,33 @@
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
     },
     "sshpk": {
-      "version": "1.13.1",
-      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz",
-      "integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M=",
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.14.1.tgz",
+      "integrity": "sha1-Ew9Zde3a2WPx1W+SuaxsUfqfg+s=",
       "requires": {
-        "asn1": "0.2.3",
-        "assert-plus": "1.0.0",
-        "bcrypt-pbkdf": "1.0.1",
-        "dashdash": "1.14.1",
-        "ecc-jsbn": "0.1.1",
-        "getpass": "0.1.7",
-        "jsbn": "0.1.1",
-        "tweetnacl": "0.14.5"
+        "asn1": "~0.2.3",
+        "assert-plus": "^1.0.0",
+        "bcrypt-pbkdf": "^1.0.0",
+        "dashdash": "^1.12.0",
+        "ecc-jsbn": "~0.1.1",
+        "getpass": "^0.1.1",
+        "jsbn": "~0.1.0",
+        "tweetnacl": "~0.14.0"
       }
     },
     "standard-version": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/standard-version/-/standard-version-4.3.0.tgz",
-      "integrity": "sha512-2UJ2BIUNa7+41PH4FvYicSQED2LCt2RXjmNFis+JZlxZtwzNnGn4uuL8WBUqHoC9b+bJ0AHIAX/bilzm+pGPeA==",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/standard-version/-/standard-version-4.4.0.tgz",
+      "integrity": "sha512-jJ8FZhnmh9xJRQLnaXiGRLaAUNItIH29lOQZGpL5fd4+jUHto9Ij6SPCYN86h6ZNNXkYq2TYiIVVF7gVyC+pcQ==",
       "requires": {
-        "chalk": "1.1.3",
-        "conventional-changelog": "1.1.7",
-        "conventional-recommended-bump": "1.1.0",
-        "dotgitignore": "1.0.3",
-        "figures": "1.7.0",
-        "fs-access": "1.0.1",
-        "semver": "5.4.1",
-        "yargs": "8.0.2"
+        "chalk": "^1.1.3",
+        "conventional-changelog": "^1.1.0",
+        "conventional-recommended-bump": "^1.0.0",
+        "dotgitignore": "^1.0.3",
+        "figures": "^1.5.0",
+        "fs-access": "^1.0.0",
+        "semver": "^5.1.0",
+        "yargs": "^8.0.1"
       },
       "dependencies": {
         "ansi-regex": {
@@ -12385,9 +14255,9 @@
           "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
           "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
           "requires": {
-            "string-width": "1.0.2",
-            "strip-ansi": "3.0.1",
-            "wrap-ansi": "2.1.0"
+            "string-width": "^1.0.1",
+            "strip-ansi": "^3.0.1",
+            "wrap-ansi": "^2.0.0"
           },
           "dependencies": {
             "string-width": {
@@ -12395,9 +14265,9 @@
               "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
               "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
               "requires": {
-                "code-point-at": "1.1.0",
-                "is-fullwidth-code-point": "1.0.0",
-                "strip-ansi": "3.0.1"
+                "code-point-at": "^1.0.0",
+                "is-fullwidth-code-point": "^1.0.0",
+                "strip-ansi": "^3.0.0"
               }
             }
           }
@@ -12405,10 +14275,10 @@
         "string-width": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-          "integrity": "sha1-q5Pyeo3BPSjKyBXEYhQ6bZASrp4=",
+          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
           "requires": {
-            "is-fullwidth-code-point": "2.0.0",
-            "strip-ansi": "4.0.0"
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^4.0.0"
           },
           "dependencies": {
             "is-fullwidth-code-point": {
@@ -12421,7 +14291,7 @@
               "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
               "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
               "requires": {
-                "ansi-regex": "3.0.0"
+                "ansi-regex": "^3.0.0"
               }
             }
           }
@@ -12431,19 +14301,19 @@
           "resolved": "https://registry.npmjs.org/yargs/-/yargs-8.0.2.tgz",
           "integrity": "sha1-YpmpBVsc78lp/355wdkY3Osiw2A=",
           "requires": {
-            "camelcase": "4.1.0",
-            "cliui": "3.2.0",
-            "decamelize": "1.2.0",
-            "get-caller-file": "1.0.2",
-            "os-locale": "2.1.0",
-            "read-pkg-up": "2.0.0",
-            "require-directory": "2.1.1",
-            "require-main-filename": "1.0.1",
-            "set-blocking": "2.0.0",
-            "string-width": "2.1.1",
-            "which-module": "2.0.0",
-            "y18n": "3.2.1",
-            "yargs-parser": "7.0.0"
+            "camelcase": "^4.1.0",
+            "cliui": "^3.2.0",
+            "decamelize": "^1.1.1",
+            "get-caller-file": "^1.0.1",
+            "os-locale": "^2.0.0",
+            "read-pkg-up": "^2.0.0",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^1.0.1",
+            "set-blocking": "^2.0.0",
+            "string-width": "^2.0.0",
+            "which-module": "^2.0.0",
+            "y18n": "^3.2.1",
+            "yargs-parser": "^7.0.0"
           }
         }
       }
@@ -12453,8 +14323,8 @@
       "resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
       "integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
       "requires": {
-        "define-property": "0.2.5",
-        "object-copy": "0.1.0"
+        "define-property": "^0.2.5",
+        "object-copy": "^0.1.0"
       },
       "dependencies": {
         "define-property": {
@@ -12462,7 +14332,7 @@
           "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "requires": {
-            "is-descriptor": "0.1.6"
+            "is-descriptor": "^0.1.0"
           }
         }
       }
@@ -12472,10 +14342,10 @@
       "resolved": "https://registry.npmjs.org/streamroller/-/streamroller-0.4.1.tgz",
       "integrity": "sha1-1DW9WXQ3Or2b2QaDWVEwhRBswF8=",
       "requires": {
-        "date-format": "0.0.0",
-        "debug": "0.7.4",
-        "mkdirp": "0.5.1",
-        "readable-stream": "1.1.14"
+        "date-format": "^0.0.0",
+        "debug": "^0.7.2",
+        "mkdirp": "^0.5.1",
+        "readable-stream": "^1.1.7"
       },
       "dependencies": {
         "debug": {
@@ -12493,10 +14363,10 @@
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
           "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
             "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
+            "string_decoder": "~0.10.x"
           }
         },
         "string_decoder": {
@@ -12516,9 +14386,9 @@
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
       "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
       "requires": {
-        "code-point-at": "1.1.0",
-        "is-fullwidth-code-point": "1.0.0",
-        "strip-ansi": "3.0.1"
+        "code-point-at": "^1.0.0",
+        "is-fullwidth-code-point": "^1.0.0",
+        "strip-ansi": "^3.0.0"
       }
     },
     "string_decoder": {
@@ -12526,20 +14396,15 @@
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
       "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
       "requires": {
-        "safe-buffer": "5.1.1"
+        "safe-buffer": "~5.1.0"
       }
-    },
-    "stringstream": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
-      "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg="
     },
     "strip-ansi": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "requires": {
-        "ansi-regex": "2.1.1"
+        "ansi-regex": "^2.0.0"
       }
     },
     "strip-bom": {
@@ -12552,8 +14417,8 @@
       "resolved": "https://registry.npmjs.org/strip-bom-stream/-/strip-bom-stream-2.0.0.tgz",
       "integrity": "sha1-+H217yYT9paKpUWr/h7HKLaoKco=",
       "requires": {
-        "first-chunk-stream": "2.0.0",
-        "strip-bom": "2.0.0"
+        "first-chunk-stream": "^2.0.0",
+        "strip-bom": "^2.0.0"
       },
       "dependencies": {
         "strip-bom": {
@@ -12561,7 +14426,7 @@
           "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
           "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
           "requires": {
-            "is-utf8": "0.2.1"
+            "is-utf8": "^0.2.0"
           }
         }
       }
@@ -12576,7 +14441,7 @@
       "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
       "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
       "requires": {
-        "get-stdin": "4.0.1"
+        "get-stdin": "^4.0.1"
       }
     },
     "strip-json-comments": {
@@ -12601,12 +14466,12 @@
       "integrity": "sha512-UUkEAPdSGxtRpiV9ozJ5cMTtYiqz7Ni1OGqLXRCynrvzdtR1p+cfOWe2RJLwvUG8hNanaSRjecIqwOjqeatDsA==",
       "dev": true,
       "requires": {
-        "ajv": "5.5.2",
-        "ajv-keywords": "2.1.1",
-        "chalk": "2.3.2",
-        "lodash": "4.17.4",
+        "ajv": "^5.2.3",
+        "ajv-keywords": "^2.1.0",
+        "chalk": "^2.1.0",
+        "lodash": "^4.17.4",
         "slice-ansi": "1.0.0",
-        "string-width": "2.1.1"
+        "string-width": "^2.1.1"
       },
       "dependencies": {
         "ansi-regex": {
@@ -12621,7 +14486,7 @@
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
-            "color-convert": "1.9.1"
+            "color-convert": "^1.9.0"
           }
         },
         "chalk": {
@@ -12630,9 +14495,9 @@
           "integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
           "dev": true,
           "requires": {
-            "ansi-styles": "3.2.1",
-            "escape-string-regexp": "1.0.5",
-            "supports-color": "5.3.0"
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
           }
         },
         "has-flag": {
@@ -12653,8 +14518,8 @@
           "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
           "dev": true,
           "requires": {
-            "is-fullwidth-code-point": "2.0.0",
-            "strip-ansi": "4.0.0"
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^4.0.0"
           }
         },
         "strip-ansi": {
@@ -12663,7 +14528,7 @@
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "3.0.0"
+            "ansi-regex": "^3.0.0"
           }
         },
         "supports-color": {
@@ -12672,7 +14537,7 @@
           "integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
           "dev": true,
           "requires": {
-            "has-flag": "3.0.0"
+            "has-flag": "^3.0.0"
           }
         }
       }
@@ -12707,8 +14572,8 @@
       "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
       "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
       "requires": {
-        "readable-stream": "2.3.3",
-        "xtend": "4.0.1"
+        "readable-stream": "^2.1.5",
+        "xtend": "~4.0.1"
       }
     },
     "timed-out": {
@@ -12721,7 +14586,7 @@
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.29.tgz",
       "integrity": "sha1-8lEl/w3Z2jzLDC3Tce4SiLuRKMA=",
       "requires": {
-        "os-tmpdir": "1.0.2"
+        "os-tmpdir": "~1.0.1"
       }
     },
     "to-object-path": {
@@ -12729,7 +14594,7 @@
       "resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
       "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
       "requires": {
-        "kind-of": "3.2.2"
+        "kind-of": "^3.0.2"
       }
     },
     "to-regex": {
@@ -12737,10 +14602,10 @@
       "resolved": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz",
       "integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
       "requires": {
-        "define-property": "2.0.2",
-        "extend-shallow": "3.0.2",
-        "regex-not": "1.0.2",
-        "safe-regex": "1.1.0"
+        "define-property": "^2.0.2",
+        "extend-shallow": "^3.0.2",
+        "regex-not": "^1.0.2",
+        "safe-regex": "^1.1.0"
       }
     },
     "to-regex-range": {
@@ -12748,16 +14613,16 @@
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
       "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
       "requires": {
-        "is-number": "3.0.0",
-        "repeat-string": "1.6.1"
+        "is-number": "^3.0.0",
+        "repeat-string": "^1.6.1"
       }
     },
     "tough-cookie": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.3.tgz",
-      "integrity": "sha1-C2GKVWW23qkL80JdBNVe3EdadWE=",
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
+      "integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
       "requires": {
-        "punycode": "1.4.1"
+        "punycode": "^1.4.1"
       }
     },
     "traverse": {
@@ -12780,7 +14645,7 @@
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
       "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
       "requires": {
-        "safe-buffer": "5.1.1"
+        "safe-buffer": "^5.0.1"
       }
     },
     "tweetnacl": {
@@ -12795,7 +14660,7 @@
       "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
       "dev": true,
       "requires": {
-        "prelude-ls": "1.1.2"
+        "prelude-ls": "~1.1.2"
       }
     },
     "type-detect": {
@@ -12814,9 +14679,9 @@
       "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
       "optional": true,
       "requires": {
-        "source-map": "0.5.7",
-        "uglify-to-browserify": "1.0.2",
-        "yargs": "3.10.0"
+        "source-map": "~0.5.1",
+        "uglify-to-browserify": "~1.0.0",
+        "yargs": "~3.10.0"
       },
       "dependencies": {
         "source-map": {
@@ -12838,10 +14703,10 @@
       "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.0.tgz",
       "integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
       "requires": {
-        "arr-union": "3.1.0",
-        "get-value": "2.0.6",
-        "is-extendable": "0.1.1",
-        "set-value": "0.4.3"
+        "arr-union": "^3.1.0",
+        "get-value": "^2.0.6",
+        "is-extendable": "^0.1.1",
+        "set-value": "^0.4.3"
       },
       "dependencies": {
         "extend-shallow": {
@@ -12849,7 +14714,7 @@
           "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "requires": {
-            "is-extendable": "0.1.1"
+            "is-extendable": "^0.1.0"
           }
         },
         "set-value": {
@@ -12857,10 +14722,10 @@
           "resolved": "https://registry.npmjs.org/set-value/-/set-value-0.4.3.tgz",
           "integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
           "requires": {
-            "extend-shallow": "2.0.1",
-            "is-extendable": "0.1.1",
-            "is-plain-object": "2.0.4",
-            "to-object-path": "0.3.0"
+            "extend-shallow": "^2.0.1",
+            "is-extendable": "^0.1.1",
+            "is-plain-object": "^2.0.1",
+            "to-object-path": "^0.3.0"
           }
         }
       }
@@ -12870,8 +14735,8 @@
       "resolved": "https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz",
       "integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
       "requires": {
-        "has-value": "0.3.1",
-        "isobject": "3.0.1"
+        "has-value": "^0.3.1",
+        "isobject": "^3.0.0"
       },
       "dependencies": {
         "has-value": {
@@ -12879,9 +14744,9 @@
           "resolved": "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz",
           "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
           "requires": {
-            "get-value": "2.0.6",
-            "has-values": "0.1.4",
-            "isobject": "2.1.0"
+            "get-value": "^2.0.3",
+            "has-values": "^0.1.4",
+            "isobject": "^2.0.0"
           },
           "dependencies": {
             "isobject": {
@@ -12906,7 +14771,7 @@
       "resolved": "https://registry.npmjs.org/untildify/-/untildify-2.1.0.tgz",
       "integrity": "sha1-F+soB5h/dpUunASF/DEdBqgmouA=",
       "requires": {
-        "os-homedir": "1.0.2"
+        "os-homedir": "^1.0.0"
       }
     },
     "unzip-response": {
@@ -12919,12 +14784,12 @@
       "resolved": "https://registry.npmjs.org/unzip2/-/unzip2-0.2.5.tgz",
       "integrity": "sha1-TveleaeMFcUfVQ9qBT2xlBSciZI=",
       "requires": {
-        "binary": "0.3.0",
-        "fstream": "0.1.31",
-        "match-stream": "0.0.2",
-        "pullstream": "0.4.1",
-        "readable-stream": "1.0.34",
-        "setimmediate": "1.0.5"
+        "binary": "~0.3.0",
+        "fstream": "~0.1.21",
+        "match-stream": "~0.0.2",
+        "pullstream": "~0.4.0",
+        "readable-stream": "~1.0.0",
+        "setimmediate": "~1.0.1"
       },
       "dependencies": {
         "isarray": {
@@ -12937,10 +14802,10 @@
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
             "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
+            "string_decoder": "~0.10.x"
           }
         },
         "string_decoder": {
@@ -12960,7 +14825,7 @@
       "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
       "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
       "requires": {
-        "prepend-http": "1.0.4"
+        "prepend-http": "^1.0.1"
       }
     },
     "url-to-options": {
@@ -12973,7 +14838,7 @@
       "resolved": "https://registry.npmjs.org/use/-/use-3.1.0.tgz",
       "integrity": "sha512-6UJEQM/L+mzC3ZJNM56Q4DFGLX/evKGRg15UJHGB9X5j5Z3AFbgZvjUh2yq/UJUY4U5dh7Fal++XbNg1uzpRAw==",
       "requires": {
-        "kind-of": "6.0.2"
+        "kind-of": "^6.0.2"
       },
       "dependencies": {
         "kind-of": {
@@ -12988,7 +14853,7 @@
       "resolved": "https://registry.npmjs.org/user-home/-/user-home-2.0.0.tgz",
       "integrity": "sha1-nHC/2Babwdy/SGBODwS4tJzenp8=",
       "requires": {
-        "os-homedir": "1.0.2"
+        "os-homedir": "^1.0.0"
       }
     },
     "util-deprecate": {
@@ -12997,17 +14862,17 @@
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "uuid": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
-      "integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g=="
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.2.1.tgz",
+      "integrity": "sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA=="
     },
     "validate-npm-package-license": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
       "integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
       "requires": {
-        "spdx-correct": "1.0.2",
-        "spdx-expression-parse": "1.0.4"
+        "spdx-correct": "~1.0.0",
+        "spdx-expression-parse": "~1.0.0"
       }
     },
     "verror": {
@@ -13015,9 +14880,9 @@
       "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
       "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
       "requires": {
-        "assert-plus": "1.0.0",
+        "assert-plus": "^1.0.0",
         "core-util-is": "1.0.2",
-        "extsprintf": "1.3.0"
+        "extsprintf": "^1.2.0"
       }
     },
     "vinyl": {
@@ -13025,12 +14890,12 @@
       "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-2.1.0.tgz",
       "integrity": "sha1-Ah+cLPlR1rk5lDyJ617lrdT9kkw=",
       "requires": {
-        "clone": "2.1.1",
-        "clone-buffer": "1.0.0",
-        "clone-stats": "1.0.0",
-        "cloneable-readable": "1.0.0",
-        "remove-trailing-separator": "1.1.0",
-        "replace-ext": "1.0.0"
+        "clone": "^2.1.1",
+        "clone-buffer": "^1.0.0",
+        "clone-stats": "^1.0.0",
+        "cloneable-readable": "^1.0.0",
+        "remove-trailing-separator": "^1.0.1",
+        "replace-ext": "^1.0.0"
       }
     },
     "vinyl-file": {
@@ -13038,12 +14903,12 @@
       "resolved": "https://registry.npmjs.org/vinyl-file/-/vinyl-file-2.0.0.tgz",
       "integrity": "sha1-p+v1/779obfRjRQPyweyI++2dRo=",
       "requires": {
-        "graceful-fs": "4.1.11",
-        "pify": "2.3.0",
-        "pinkie-promise": "2.0.1",
-        "strip-bom": "2.0.0",
-        "strip-bom-stream": "2.0.0",
-        "vinyl": "1.2.0"
+        "graceful-fs": "^4.1.2",
+        "pify": "^2.3.0",
+        "pinkie-promise": "^2.0.0",
+        "strip-bom": "^2.0.0",
+        "strip-bom-stream": "^2.0.0",
+        "vinyl": "^1.1.0"
       },
       "dependencies": {
         "clone": {
@@ -13066,7 +14931,7 @@
           "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
           "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
           "requires": {
-            "is-utf8": "0.2.1"
+            "is-utf8": "^0.2.0"
           }
         },
         "vinyl": {
@@ -13074,8 +14939,8 @@
           "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-1.2.0.tgz",
           "integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
           "requires": {
-            "clone": "1.0.3",
-            "clone-stats": "0.0.1",
+            "clone": "^1.0.0",
+            "clone-stats": "^0.0.1",
             "replace-ext": "0.0.1"
           }
         }
@@ -13086,7 +14951,7 @@
       "resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
       "integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
       "requires": {
-        "isexe": "2.0.0"
+        "isexe": "^2.0.0"
       }
     },
     "which-module": {
@@ -13110,8 +14975,8 @@
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
       "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
       "requires": {
-        "string-width": "1.0.2",
-        "strip-ansi": "3.0.1"
+        "string-width": "^1.0.1",
+        "strip-ansi": "^3.0.1"
       }
     },
     "wrappy": {
@@ -13125,7 +14990,7 @@
       "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
       "dev": true,
       "requires": {
-        "mkdirp": "0.5.1"
+        "mkdirp": "^0.5.1"
       }
     },
     "xtend": {
@@ -13139,8 +15004,8 @@
       "integrity": "sha1-bLNaAk7pS0myUH7jh4loxrquw5g=",
       "dev": true,
       "requires": {
-        "dateformat": "1.0.12",
-        "mkdirp": "0.5.1"
+        "dateformat": "^1.0.12",
+        "mkdirp": "^0.5.1"
       },
       "dependencies": {
         "dateformat": {
@@ -13149,8 +15014,8 @@
           "integrity": "sha1-nxJLZ1lMk3/3BpMuSmQsyo27/uk=",
           "dev": true,
           "requires": {
-            "get-stdin": "4.0.1",
-            "meow": "3.7.0"
+            "get-stdin": "^4.0.1",
+            "meow": "^3.3.0"
           }
         }
       }
@@ -13171,9 +15036,9 @@
       "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
       "optional": true,
       "requires": {
-        "camelcase": "1.2.1",
-        "cliui": "2.1.0",
-        "decamelize": "1.2.0",
+        "camelcase": "^1.0.2",
+        "cliui": "^2.1.0",
+        "decamelize": "^1.0.0",
         "window-size": "0.1.0"
       }
     },
@@ -13182,7 +15047,7 @@
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-7.0.0.tgz",
       "integrity": "sha1-jQrELxbqVd69MyyvTEA4s+P139k=",
       "requires": {
-        "camelcase": "4.1.0"
+        "camelcase": "^4.1.0"
       },
       "dependencies": {
         "camelcase": {
@@ -13202,18 +15067,18 @@
       "resolved": "https://registry.npmjs.org/yeoman-environment/-/yeoman-environment-1.6.6.tgz",
       "integrity": "sha1-zYX6Z9FWBg5EDXgH1+988NLR1nE=",
       "requires": {
-        "chalk": "1.1.3",
-        "debug": "2.6.9",
-        "diff": "2.2.3",
-        "escape-string-regexp": "1.0.5",
-        "globby": "4.1.0",
-        "grouped-queue": "0.3.3",
-        "inquirer": "1.2.3",
-        "lodash": "4.17.4",
-        "log-symbols": "1.0.2",
-        "mem-fs": "1.1.3",
-        "text-table": "0.2.0",
-        "untildify": "2.1.0"
+        "chalk": "^1.0.0",
+        "debug": "^2.0.0",
+        "diff": "^2.1.2",
+        "escape-string-regexp": "^1.0.2",
+        "globby": "^4.0.0",
+        "grouped-queue": "^0.3.0",
+        "inquirer": "^1.0.2",
+        "lodash": "^4.11.1",
+        "log-symbols": "^1.0.1",
+        "mem-fs": "^1.1.0",
+        "text-table": "^0.2.0",
+        "untildify": "^2.0.0"
       },
       "dependencies": {
         "glob": {
@@ -13221,11 +15086,11 @@
           "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
           "integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=",
           "requires": {
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "2 || 3",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         },
         "globby": {
@@ -13233,12 +15098,12 @@
           "resolved": "https://registry.npmjs.org/globby/-/globby-4.1.0.tgz",
           "integrity": "sha1-CA9UVJ7BuCpsYOYx/ILhIR2+lfg=",
           "requires": {
-            "array-union": "1.0.2",
-            "arrify": "1.0.1",
-            "glob": "6.0.4",
-            "object-assign": "4.1.1",
-            "pify": "2.3.0",
-            "pinkie-promise": "2.0.1"
+            "array-union": "^1.0.1",
+            "arrify": "^1.0.0",
+            "glob": "^6.0.1",
+            "object-assign": "^4.0.1",
+            "pify": "^2.0.0",
+            "pinkie-promise": "^2.0.0"
           }
         },
         "object-assign": {
@@ -13253,44 +15118,44 @@
       "resolved": "https://registry.npmjs.org/yeoman-generator/-/yeoman-generator-1.1.1.tgz",
       "integrity": "sha1-QMK09s374F4ZUv3XKTPw2JJdvfU=",
       "requires": {
-        "async": "2.6.0",
-        "chalk": "1.1.3",
-        "class-extend": "0.1.2",
-        "cli-table": "0.3.1",
-        "cross-spawn": "5.1.0",
-        "dargs": "5.1.0",
-        "dateformat": "2.2.0",
-        "debug": "2.6.9",
-        "detect-conflict": "1.0.1",
-        "error": "7.0.2",
-        "find-up": "2.1.0",
-        "github-username": "3.0.0",
-        "glob": "7.1.2",
-        "istextorbinary": "2.1.0",
-        "lodash": "4.17.4",
-        "mem-fs-editor": "3.0.2",
-        "minimist": "1.2.0",
-        "mkdirp": "0.5.1",
-        "path-exists": "3.0.0",
-        "path-is-absolute": "1.0.1",
-        "pretty-bytes": "4.0.2",
-        "read-chunk": "2.1.0",
-        "read-pkg-up": "2.0.0",
-        "rimraf": "2.6.2",
-        "run-async": "2.3.0",
-        "shelljs": "0.7.8",
-        "text-table": "0.2.0",
-        "through2": "2.0.3",
-        "user-home": "2.0.0",
-        "yeoman-environment": "1.6.6"
+        "async": "^2.0.0",
+        "chalk": "^1.0.0",
+        "class-extend": "^0.1.0",
+        "cli-table": "^0.3.1",
+        "cross-spawn": "^5.0.1",
+        "dargs": "^5.1.0",
+        "dateformat": "^2.0.0",
+        "debug": "^2.1.0",
+        "detect-conflict": "^1.0.0",
+        "error": "^7.0.2",
+        "find-up": "^2.1.0",
+        "github-username": "^3.0.0",
+        "glob": "^7.0.3",
+        "istextorbinary": "^2.1.0",
+        "lodash": "^4.11.1",
+        "mem-fs-editor": "^3.0.0",
+        "minimist": "^1.2.0",
+        "mkdirp": "^0.5.0",
+        "path-exists": "^3.0.0",
+        "path-is-absolute": "^1.0.0",
+        "pretty-bytes": "^4.0.2",
+        "read-chunk": "^2.0.0",
+        "read-pkg-up": "^2.0.0",
+        "rimraf": "^2.2.0",
+        "run-async": "^2.0.0",
+        "shelljs": "^0.7.0",
+        "text-table": "^0.2.0",
+        "through2": "^2.0.0",
+        "user-home": "^2.0.0",
+        "yeoman-environment": "^1.1.0"
       },
       "dependencies": {
         "async": {
-          "version": "2.6.0",
-          "resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
-          "integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
+          "version": "2.6.1",
+          "resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
+          "integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
           "requires": {
-            "lodash": "4.17.4"
+            "lodash": "^4.17.10"
           }
         },
         "minimist": {
@@ -13305,14 +15170,14 @@
       "resolved": "https://registry.npmjs.org/yeoman-test/-/yeoman-test-1.7.2.tgz",
       "integrity": "sha512-4KFaEWcRhLq1QC9EtdU3Miw/QxlEcNcF4VfgQdQsTJOa2nSXL/NVsMTRoMkki7ssYQornCOqGgXJA5/VUICtcw==",
       "requires": {
-        "inquirer": "5.2.0",
-        "lodash": "4.17.4",
-        "mkdirp": "0.5.1",
-        "pinkie-promise": "2.0.1",
-        "rimraf": "2.6.2",
-        "sinon": "5.0.7",
-        "yeoman-environment": "2.1.1",
-        "yeoman-generator": "2.0.5"
+        "inquirer": "^5.2.0",
+        "lodash": "^4.3.0",
+        "mkdirp": "^0.5.1",
+        "pinkie-promise": "^2.0.1",
+        "rimraf": "^2.4.4",
+        "sinon": "^5.0.7",
+        "yeoman-environment": "^2.0.0",
+        "yeoman-generator": "^2.0.5"
       },
       "dependencies": {
         "ansi-escapes": {
@@ -13330,7 +15195,7 @@
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "requires": {
-            "color-convert": "1.9.1"
+            "color-convert": "^1.9.0"
           }
         },
         "async": {
@@ -13338,7 +15203,7 @@
           "resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
           "integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
           "requires": {
-            "lodash": "4.17.4"
+            "lodash": "^4.14.0"
           }
         },
         "chalk": {
@@ -13346,9 +15211,9 @@
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
           "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
           "requires": {
-            "ansi-styles": "3.2.1",
-            "escape-string-regexp": "1.0.5",
-            "supports-color": "5.4.0"
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
           }
         },
         "cli-cursor": {
@@ -13356,7 +15221,7 @@
           "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
           "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
           "requires": {
-            "restore-cursor": "2.0.0"
+            "restore-cursor": "^2.0.0"
           }
         },
         "cross-spawn": {
@@ -13364,11 +15229,11 @@
           "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
           "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
           "requires": {
-            "nice-try": "1.0.4",
-            "path-key": "2.0.1",
-            "semver": "5.5.0",
-            "shebang-command": "1.2.0",
-            "which": "1.3.0"
+            "nice-try": "^1.0.4",
+            "path-key": "^2.0.1",
+            "semver": "^5.5.0",
+            "shebang-command": "^1.2.0",
+            "which": "^1.2.9"
           }
         },
         "dateformat": {
@@ -13404,9 +15269,9 @@
           "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
           "integrity": "sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==",
           "requires": {
-            "chardet": "0.4.2",
-            "iconv-lite": "0.4.19",
-            "tmp": "0.0.33"
+            "chardet": "^0.4.0",
+            "iconv-lite": "^0.4.17",
+            "tmp": "^0.0.33"
           }
         },
         "figures": {
@@ -13414,7 +15279,7 @@
           "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
           "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
           "requires": {
-            "escape-string-regexp": "1.0.5"
+            "escape-string-regexp": "^1.0.5"
           }
         },
         "gh-got": {
@@ -13422,8 +15287,8 @@
           "resolved": "https://registry.npmjs.org/gh-got/-/gh-got-6.0.0.tgz",
           "integrity": "sha512-F/mS+fsWQMo1zfgG9MD8KWvTWPPzzhuVwY++fhQ5Ggd+0P+CAMHtzMZhNxG+TqGfHDChJKsbh6otfMGqO2AKBw==",
           "requires": {
-            "got": "7.1.0",
-            "is-plain-obj": "1.1.0"
+            "got": "^7.0.0",
+            "is-plain-obj": "^1.1.0"
           }
         },
         "github-username": {
@@ -13431,7 +15296,7 @@
           "resolved": "https://registry.npmjs.org/github-username/-/github-username-4.1.0.tgz",
           "integrity": "sha1-y+KABBiDIG2kISrp5LXxacML9Bc=",
           "requires": {
-            "gh-got": "6.0.0"
+            "gh-got": "^6.0.0"
           }
         },
         "globby": {
@@ -13439,13 +15304,13 @@
           "resolved": "https://registry.npmjs.org/globby/-/globby-8.0.1.tgz",
           "integrity": "sha512-oMrYrJERnKBLXNLVTqhm3vPEdJ/b2ZE28xN4YARiix1NOIOBPEpOUnm844K1iu/BkphCaf2WNFwMszv8Soi1pw==",
           "requires": {
-            "array-union": "1.0.2",
-            "dir-glob": "2.0.0",
-            "fast-glob": "2.2.2",
-            "glob": "7.1.2",
-            "ignore": "3.3.7",
-            "pify": "3.0.0",
-            "slash": "1.0.0"
+            "array-union": "^1.0.1",
+            "dir-glob": "^2.0.0",
+            "fast-glob": "^2.0.2",
+            "glob": "^7.1.2",
+            "ignore": "^3.3.5",
+            "pify": "^3.0.0",
+            "slash": "^1.0.0"
           }
         },
         "got": {
@@ -13453,20 +15318,20 @@
           "resolved": "https://registry.npmjs.org/got/-/got-7.1.0.tgz",
           "integrity": "sha512-Y5WMo7xKKq1muPsxD+KmrR8DH5auG7fBdDVueZwETwV6VytKyU9OX/ddpq2/1hp1vIPvVb4T81dKQz3BivkNLw==",
           "requires": {
-            "decompress-response": "3.3.0",
-            "duplexer3": "0.1.4",
-            "get-stream": "3.0.0",
-            "is-plain-obj": "1.1.0",
-            "is-retry-allowed": "1.1.0",
-            "is-stream": "1.1.0",
-            "isurl": "1.0.0",
-            "lowercase-keys": "1.0.0",
-            "p-cancelable": "0.3.0",
-            "p-timeout": "1.2.1",
-            "safe-buffer": "5.1.1",
-            "timed-out": "4.0.1",
-            "url-parse-lax": "1.0.0",
-            "url-to-options": "1.0.1"
+            "decompress-response": "^3.2.0",
+            "duplexer3": "^0.1.4",
+            "get-stream": "^3.0.0",
+            "is-plain-obj": "^1.1.0",
+            "is-retry-allowed": "^1.0.0",
+            "is-stream": "^1.0.0",
+            "isurl": "^1.0.0-alpha5",
+            "lowercase-keys": "^1.0.0",
+            "p-cancelable": "^0.3.0",
+            "p-timeout": "^1.1.1",
+            "safe-buffer": "^5.0.1",
+            "timed-out": "^4.0.0",
+            "url-parse-lax": "^1.0.0",
+            "url-to-options": "^1.0.1"
           }
         },
         "inquirer": {
@@ -13474,19 +15339,19 @@
           "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-5.2.0.tgz",
           "integrity": "sha512-E9BmnJbAKLPGonz0HeWHtbKf+EeSP93paWO3ZYoUpq/aowXvYGjjCSuashhXPpzbArIjBbji39THkxTz9ZeEUQ==",
           "requires": {
-            "ansi-escapes": "3.1.0",
-            "chalk": "2.4.1",
-            "cli-cursor": "2.1.0",
-            "cli-width": "2.2.0",
-            "external-editor": "2.2.0",
-            "figures": "2.0.0",
-            "lodash": "4.17.4",
+            "ansi-escapes": "^3.0.0",
+            "chalk": "^2.0.0",
+            "cli-cursor": "^2.1.0",
+            "cli-width": "^2.0.0",
+            "external-editor": "^2.1.0",
+            "figures": "^2.0.0",
+            "lodash": "^4.3.0",
             "mute-stream": "0.0.7",
-            "run-async": "2.3.0",
-            "rxjs": "5.5.10",
-            "string-width": "2.1.1",
-            "strip-ansi": "4.0.0",
-            "through": "2.3.8"
+            "run-async": "^2.2.0",
+            "rxjs": "^5.5.2",
+            "string-width": "^2.1.0",
+            "strip-ansi": "^4.0.0",
+            "through": "^2.3.6"
           }
         },
         "is-fullwidth-code-point": {
@@ -13499,9 +15364,9 @@
           "resolved": "https://registry.npmjs.org/istextorbinary/-/istextorbinary-2.2.1.tgz",
           "integrity": "sha512-TS+hoFl8Z5FAFMK38nhBkdLt44CclNRgDHWeMgsV8ko3nDlr/9UI2Sf839sW7enijf8oKsZYXRvM8g0it9Zmcw==",
           "requires": {
-            "binaryextensions": "2.0.0",
-            "editions": "1.3.3",
-            "textextensions": "2.1.0"
+            "binaryextensions": "2",
+            "editions": "^1.3.3",
+            "textextensions": "2"
           }
         },
         "load-json-file": {
@@ -13509,10 +15374,10 @@
           "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
           "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
           "requires": {
-            "graceful-fs": "4.1.11",
-            "parse-json": "4.0.0",
-            "pify": "3.0.0",
-            "strip-bom": "3.0.0"
+            "graceful-fs": "^4.1.2",
+            "parse-json": "^4.0.0",
+            "pify": "^3.0.0",
+            "strip-bom": "^3.0.0"
           }
         },
         "log-symbols": {
@@ -13520,7 +15385,7 @@
           "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-2.2.0.tgz",
           "integrity": "sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==",
           "requires": {
-            "chalk": "2.4.1"
+            "chalk": "^2.0.1"
           }
         },
         "mem-fs-editor": {
@@ -13528,17 +15393,17 @@
           "resolved": "https://registry.npmjs.org/mem-fs-editor/-/mem-fs-editor-4.0.2.tgz",
           "integrity": "sha512-QHvdXLLNmwJXxKdf7x27aNUren6IoPxwcM8Sfd+S6/ddQQMcYdEtVKsh6ilpqMrU18VQuKZEaH0aCGt3JDbA0g==",
           "requires": {
-            "commondir": "1.0.1",
-            "deep-extend": "0.5.1",
-            "ejs": "2.6.1",
-            "glob": "7.1.2",
-            "globby": "8.0.1",
-            "isbinaryfile": "3.0.2",
-            "mkdirp": "0.5.1",
-            "multimatch": "2.1.0",
-            "rimraf": "2.6.2",
-            "through2": "2.0.3",
-            "vinyl": "2.1.0"
+            "commondir": "^1.0.1",
+            "deep-extend": "^0.5.1",
+            "ejs": "^2.5.9",
+            "glob": "^7.0.3",
+            "globby": "^8.0.0",
+            "isbinaryfile": "^3.0.2",
+            "mkdirp": "^0.5.0",
+            "multimatch": "^2.0.0",
+            "rimraf": "^2.2.8",
+            "through2": "^2.0.0",
+            "vinyl": "^2.0.1"
           }
         },
         "minimist": {
@@ -13556,7 +15421,7 @@
           "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
           "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
           "requires": {
-            "mimic-fn": "1.1.0"
+            "mimic-fn": "^1.0.0"
           }
         },
         "parse-json": {
@@ -13564,8 +15429,8 @@
           "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
           "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
           "requires": {
-            "error-ex": "1.3.1",
-            "json-parse-better-errors": "1.0.2"
+            "error-ex": "^1.3.1",
+            "json-parse-better-errors": "^1.0.1"
           }
         },
         "path-type": {
@@ -13573,7 +15438,7 @@
           "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
           "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
           "requires": {
-            "pify": "3.0.0"
+            "pify": "^3.0.0"
           }
         },
         "pify": {
@@ -13586,9 +15451,9 @@
           "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
           "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
           "requires": {
-            "load-json-file": "4.0.0",
-            "normalize-package-data": "2.4.0",
-            "path-type": "3.0.0"
+            "load-json-file": "^4.0.0",
+            "normalize-package-data": "^2.3.2",
+            "path-type": "^3.0.0"
           }
         },
         "read-pkg-up": {
@@ -13596,8 +15461,8 @@
           "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-3.0.0.tgz",
           "integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
           "requires": {
-            "find-up": "2.1.0",
-            "read-pkg": "3.0.0"
+            "find-up": "^2.0.0",
+            "read-pkg": "^3.0.0"
           }
         },
         "restore-cursor": {
@@ -13605,8 +15470,8 @@
           "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
           "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
           "requires": {
-            "onetime": "2.0.1",
-            "signal-exit": "3.0.2"
+            "onetime": "^2.0.0",
+            "signal-exit": "^3.0.2"
           }
         },
         "semver": {
@@ -13619,9 +15484,9 @@
           "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.2.tgz",
           "integrity": "sha512-pRXeNrCA2Wd9itwhvLp5LZQvPJ0wU6bcjaTMywHHGX5XWhVN2nzSu7WV0q+oUY7mGK3mgSkDDzP3MgjqdyIgbQ==",
           "requires": {
-            "glob": "7.1.2",
-            "interpret": "1.1.0",
-            "rechoir": "0.6.2"
+            "glob": "^7.0.0",
+            "interpret": "^1.0.0",
+            "rechoir": "^0.6.2"
           }
         },
         "string-width": {
@@ -13629,8 +15494,8 @@
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
           "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
           "requires": {
-            "is-fullwidth-code-point": "2.0.0",
-            "strip-ansi": "4.0.0"
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^4.0.0"
           }
         },
         "strip-ansi": {
@@ -13638,7 +15503,7 @@
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "requires": {
-            "ansi-regex": "3.0.0"
+            "ansi-regex": "^3.0.0"
           }
         },
         "supports-color": {
@@ -13646,7 +15511,7 @@
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
           "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
           "requires": {
-            "has-flag": "3.0.0"
+            "has-flag": "^3.0.0"
           }
         },
         "tmp": {
@@ -13654,7 +15519,7 @@
           "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
           "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
           "requires": {
-            "os-tmpdir": "1.0.2"
+            "os-tmpdir": "~1.0.2"
           }
         },
         "untildify": {
@@ -13667,21 +15532,21 @@
           "resolved": "https://registry.npmjs.org/yeoman-environment/-/yeoman-environment-2.1.1.tgz",
           "integrity": "sha512-IBLwCUrJrDxBYuwdYm1wuF3O/CR2LpXR0rFS684QOrU6x69DPPrsdd20dZOFaedZ/M9sON7po73WhO3I1CbgNQ==",
           "requires": {
-            "chalk": "2.4.1",
-            "cross-spawn": "6.0.5",
-            "debug": "3.1.0",
-            "diff": "3.5.0",
-            "escape-string-regexp": "1.0.5",
-            "globby": "8.0.1",
-            "grouped-queue": "0.3.3",
-            "inquirer": "5.2.0",
-            "is-scoped": "1.0.0",
-            "lodash": "4.17.10",
-            "log-symbols": "2.2.0",
-            "mem-fs": "1.1.3",
-            "strip-ansi": "4.0.0",
-            "text-table": "0.2.0",
-            "untildify": "3.0.2"
+            "chalk": "^2.1.0",
+            "cross-spawn": "^6.0.5",
+            "debug": "^3.1.0",
+            "diff": "^3.3.1",
+            "escape-string-regexp": "^1.0.2",
+            "globby": "^8.0.1",
+            "grouped-queue": "^0.3.3",
+            "inquirer": "^5.2.0",
+            "is-scoped": "^1.0.0",
+            "lodash": "^4.17.10",
+            "log-symbols": "^2.1.0",
+            "mem-fs": "^1.1.0",
+            "strip-ansi": "^4.0.0",
+            "text-table": "^0.2.0",
+            "untildify": "^3.0.2"
           },
           "dependencies": {
             "lodash": {
@@ -13696,31 +15561,31 @@
           "resolved": "https://registry.npmjs.org/yeoman-generator/-/yeoman-generator-2.0.5.tgz",
           "integrity": "sha512-rV6tJ8oYzm4mmdF2T3wjY+Q42jKF2YiiD0VKfJ8/0ZYwmhCKC9Xs2346HVLPj/xE13i68psnFJv7iS6gWRkeAg==",
           "requires": {
-            "async": "2.6.0",
-            "chalk": "2.4.1",
-            "cli-table": "0.3.1",
-            "cross-spawn": "6.0.5",
-            "dargs": "5.1.0",
-            "dateformat": "3.0.3",
-            "debug": "3.1.0",
-            "detect-conflict": "1.0.1",
-            "error": "7.0.2",
-            "find-up": "2.1.0",
-            "github-username": "4.1.0",
-            "istextorbinary": "2.2.1",
-            "lodash": "4.17.10",
-            "make-dir": "1.3.0",
-            "mem-fs-editor": "4.0.2",
-            "minimist": "1.2.0",
-            "pretty-bytes": "4.0.2",
-            "read-chunk": "2.1.0",
-            "read-pkg-up": "3.0.0",
-            "rimraf": "2.6.2",
-            "run-async": "2.3.0",
-            "shelljs": "0.8.2",
-            "text-table": "0.2.0",
-            "through2": "2.0.3",
-            "yeoman-environment": "2.1.1"
+            "async": "^2.6.0",
+            "chalk": "^2.3.0",
+            "cli-table": "^0.3.1",
+            "cross-spawn": "^6.0.5",
+            "dargs": "^5.1.0",
+            "dateformat": "^3.0.3",
+            "debug": "^3.1.0",
+            "detect-conflict": "^1.0.0",
+            "error": "^7.0.2",
+            "find-up": "^2.1.0",
+            "github-username": "^4.0.0",
+            "istextorbinary": "^2.2.1",
+            "lodash": "^4.17.10",
+            "make-dir": "^1.1.0",
+            "mem-fs-editor": "^4.0.0",
+            "minimist": "^1.2.0",
+            "pretty-bytes": "^4.0.2",
+            "read-chunk": "^2.1.0",
+            "read-pkg-up": "^3.0.0",
+            "rimraf": "^2.6.2",
+            "run-async": "^2.0.0",
+            "shelljs": "^0.8.0",
+            "text-table": "^0.2.0",
+            "through2": "^2.0.0",
+            "yeoman-environment": "^2.0.5"
           },
           "dependencies": {
             "lodash": {

--- a/generator-java/package.json
+++ b/generator-java/package.json
@@ -11,26 +11,27 @@
   "dependencies": {
     "common-codegen-tests": "2.2.3",
     "extend": "^3.0.1",
-    "generator-ibm-cloud-enablement": "^0.13.7",
+    "generator-ibm-cloud-enablement": "^0.14.3",
     "generator-ibm-java-liberty": "8.6.2",
     "generator-ibm-java-spring": "2.2.3",
-    "generator-ibm-service-enablement": "0.7.0",
-    "generator-ibm-usecase-enablement": "3.0.0",
+    "generator-ibm-service-enablement": "^1.1.9",
+    "generator-ibm-usecase-enablement": "^3.2.2",
     "handlebars": "^4.0.0",
     "ibm-java-codegen-common": "3.0.1",
     "npm": "^6.0.1",
     "yeoman-assert": "^2.2.2",
-    "yeoman-generator": "^1.0.0",
+    "yeoman-generator": "^1.1.1",
     "yeoman-test": "^1.7.2"
   },
   "devDependencies": {
-    "coveralls": "^2.13.3",
+    "coveralls": "^3.0.1",
     "eslint": "^4.19.1",
+    "eslint-plugin-ejs": "0.0.2",
     "js-yaml": "^3.11.0",
     "mocha": "^3.5.3",
     "mocha-multi-reporters": "^1.1.7",
     "nyc": "^11.8.0",
-    "standard-version": "^4.3.0",
+    "standard-version": "^4.4.0",
     "xunit-file": "^1.0.0"
   },
   "scripts": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,3 +1,0 @@
-{
-  "lockfileVersion": 1
-}


### PR DESCRIPTION
Kube secrets for provisioned services were moved out of deployment.yaml into a bindings.yaml file.
Tests need to look for those attributes there.

resolves ibm-developer/generator-ibm-cloud-enablement#275

https://github.com/ibm-developer/generator-ibm-service-enablement/pull/241
https://github.com/ibm-developer/generator-ibm-cloud-enablement/pull/276