### PR TITLE
chore: update SDK generation endpoint

### DIFF
--- a/generator-java/generators/liberty/lib/openapi.js
+++ b/generator-java/generators/liberty/lib/openapi.js
@@ -28,7 +28,7 @@ const os = require('os')
 const log = require('../../../lib/common').log
 Promise.promisifyAll(request)
 
-const sdkGenURL = 'https://global.devx.cloud.ibm.com/sdkgen/api/generator/'
+const sdkGenURL = 'https://us-south.devx.cloud.ibm.com/sdkgen/api/generator/'
 const sdkGenCheckDelay = 3000
 
 let logger = log

--- a/generator-java/generators/liberty/lib/openapi.js
+++ b/generator-java/generators/liberty/lib/openapi.js
@@ -28,10 +28,7 @@ const os = require('os')
 const log = require('../../../lib/common').log
 Promise.promisifyAll(request)
 
-//const sdkGenURL = 'https://staging.devex.bluemix.net/sdkgen/api/generator/'
-//const sdkGenURL = 'https://dev.devex.bluemix.net/sdkgen/api/generator/'
-const sdkGenURL = 'https://us-south.devex.cloud.ibm.com/sdkgen/api/generator/'
-//const sdkGenURL = 'https://us-south.devex.bluemix.net/sdkgen/api/generator/'
+const sdkGenURL = 'https://global.devx.cloud.ibm.com/sdkgen/api/generator/'
 const sdkGenCheckDelay = 3000
 
 let logger = log

--- a/generator-java/generators/spring/lib/openapi.js
+++ b/generator-java/generators/spring/lib/openapi.js
@@ -28,8 +28,7 @@ const os = require('os')
 const log = require('../../../lib/common').log
 Promise.promisifyAll(request)
 
-const sdkGenURL = 'https://us-south.devex.cloud.ibm.com/sdkgen/api/generator/'
-//const sdkGenURL = 'https://us-south.devex.bluemix.net/sdkgen/api/generator/'
+const sdkGenURL = 'https://global.devx.cloud.ibm.com/sdkgen/api/generator/'
 const sdkGenCheckDelay = 3000
 
 let logger = log

--- a/generator-java/generators/spring/lib/openapi.js
+++ b/generator-java/generators/spring/lib/openapi.js
@@ -28,7 +28,7 @@ const os = require('os')
 const log = require('../../../lib/common').log
 Promise.promisifyAll(request)
 
-const sdkGenURL = 'https://global.devx.cloud.ibm.com/sdkgen/api/generator/'
+const sdkGenURL = 'https://us-south.devx.cloud.ibm.com/sdkgen/api/generator/'
 const sdkGenCheckDelay = 3000
 
 let logger = log


### PR DESCRIPTION
Keep regional endpoint `us-south`, but use new `devx` hostname.

Closes #164.