### PR TITLE
feat: Export common test modules

### DIFF
--- a/generator-java/index.js
+++ b/generator-java/index.js
@@ -31,7 +31,8 @@ module.exports = {
     bluemix: require('./lib/assert/assert.bluemix'),
     builds: require('./lib/assert/assert.builds'),
     framework: require('./lib/assert/assert.framework'),
-    constant: require('./lib/assert/constant.js')
+    constant: require('./lib/assert/constant.js'),
+    common: require('./lib/common').test
   },
   defaults: require('./generators/lib/defaults'),
   prompts: [require('./generators/prompts/patterns'), require('./generators/prompts/bluemix')]


### PR DESCRIPTION
Export common test modules test-maven, test-gradle and test-command.

Modules can now be accessed like 
```
const mavenUtils = require('generator-ibm-java').testAsserts.common('maven');
```

Signed-off-by: Katherine Stanley <katheris@uk.ibm.com>