### PR TITLE
fix: missing war plugin causing compile failure

### DIFF
--- a/generator-java/generators/spring/templates/build/build.gradle
+++ b/generator-java/generators/spring/templates/build/build.gradle
@@ -12,6 +12,7 @@ buildscript {
 
 apply plugin: 'java'
 apply plugin: 'org.springframework.boot'
+apply plugin: 'war'
 
 ext {
     springCloudVersion = 'Dalston.SR4'


### PR DESCRIPTION
Looks like we need the `war` plugin which has the `providedCompile` method needed during the build. We haven't built the develop branch in 2 months since Paul last made a change, so that's why we never caught this. This is only needed for Spring because the Liberty build.gradle file already includes the `war` plugin.